### PR TITLE
Perftree

### DIFF
--- a/chess/src/movegen/moves.rs
+++ b/chess/src/movegen/moves.rs
@@ -1,5 +1,5 @@
-use crate::{board::{Piece, PieceType}, bitboard::Step, movegen::attack_boards::{ATTACK_RAYS, KNIGHT_ATTACKS, KING_ATTACKS, W_PAWN_ATTACKS, W_PAWN_PUSHES, W_PAWN_DPUSHES, B_PAWN_ATTACKS, B_PAWN_DPUSHES, B_PAWN_PUSHES}};
 use std::{fmt::Display, str::FromStr};
+use crate::{board::{Piece, PieceType}, bitboard::Step, movegen::attack_boards::{ATTACK_RAYS, KNIGHT_ATTACKS, KING_ATTACKS, W_PAWN_ATTACKS, W_PAWN_PUSHES, W_PAWN_DPUSHES, B_PAWN_ATTACKS, B_PAWN_DPUSHES, B_PAWN_PUSHES}};
 use std::iter::successors;
 use crate::bitboard::Bitboard;
 use itertools::Itertools;

--- a/chess/src/movegen/moves.rs
+++ b/chess/src/movegen/moves.rs
@@ -1,5 +1,5 @@
-use std::fmt::Display;
 use crate::{board::{Piece, PieceType}, bitboard::Step, movegen::attack_boards::{ATTACK_RAYS, KNIGHT_ATTACKS, KING_ATTACKS, W_PAWN_ATTACKS, W_PAWN_PUSHES, W_PAWN_DPUSHES, B_PAWN_ATTACKS, B_PAWN_DPUSHES, B_PAWN_PUSHES}};
+use std::{fmt::Display, str::FromStr};
 use std::iter::successors;
 use crate::bitboard::Bitboard;
 use itertools::Itertools;
@@ -72,19 +72,20 @@ impl Display for Move {
         write!(f, "{}", self.src().to_alg())?;
         write!(f, "{}", self.tgt().to_alg())?;
 
-        if self.is_castle() {
-            write!(f, " (Castle)")?;
-        }
-
-        if self.is_double_push() {
-            write!(f, " (Double push)")?;
-        }
-
-        if self.is_en_passant() {
-            write!(f, " (En passant)")?;
-        }
-
         Ok(())
+    }
+}
+
+impl FromStr for Move {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        let (sq1, sq2) = dbg!(s.split_at(2));
+
+        let sq1 = Square::from_str(sq1)?;
+        let sq2 = Square::from_str(sq2)?;
+
+        Ok(Move::new(sq1, sq2))
     }
 }
 

--- a/perft/src/perft.rs
+++ b/perft/src/perft.rs
@@ -55,8 +55,8 @@ pub fn perft_divide<const BULK: bool>(board: Board, depth: usize) -> Vec<(Move, 
     let moves = board.legal_moves();
 
     moves
-        .into_iter()
-        .map(|mv| {
+        .par_iter()
+        .map(|&mv| {
             let new_board = board.play_move(mv);
             let nodes = perft::<BULK>(new_board, depth - 1);
             (mv, nodes)

--- a/perft/src/perft.rs
+++ b/perft/src/perft.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
-use rayon::prelude::*;
 use chess::{board::Board, movegen::moves::Move};
+use rayon::prelude::*;
 
 pub struct PerftResult {
     pub nodes: usize,


### PR DESCRIPTION
Add a `perftree` commmand to be used with the `perftree` debugger.

Should I just try adding my own version of this, down the line?
Seems simple enough, and would make a ton of sense to have my own `perf` tool to
have a `perf debug` command, rather than having a separate mode and output format bolted on, just so I can pipe it into an external tool.