### PR TITLE
:bug:  Make sure we retain move metadata in perft debug

### DIFF
--- a/chess/src/movegen/moves.rs
+++ b/chess/src/movegen/moves.rs
@@ -23,7 +23,7 @@ use std::iter::successors;
 /// here?
 /// cf. Rustic https://github.com/mvanthoor/rustic/blob/17b15a34b68000dffb681277c3ef6fc98f935a0b/src/movegen/defs.rs
 /// cf. Carp https://github.com/dede1751/carp/blob/main/chess/src/moves.rs
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Move(u16);
 
 impl Move {

--- a/chess/src/movegen/play_move.rs
+++ b/chess/src/movegen/play_move.rs
@@ -77,7 +77,7 @@ impl Board {
 
         // Update en-passant square
         if mv.is_double_push() {
-            new_board.en_passant = mv.src().forward(self.current)
+            new_board.en_passant = mv.src().forward(self.current);
         } else {
             new_board.en_passant = None;
         }

--- a/simbelmyne/src/main.rs
+++ b/simbelmyne/src/main.rs
@@ -122,6 +122,7 @@ fn main() {
         highlights: Bitboard::EMPTY,
     };
     loop {
+        println!("FEN: {}", game.board.to_fen());
         if let Err(error) = game.play_turn() {
             eprintln!("[{}]: {error}", "Error".red());
         }


### PR DESCRIPTION
When comparing our results to stockfish, we were serializing our moves to algebraic strings, throwing them all into a hashset, and then converting them back into moves when it came time to play them.

That means we're actually _losing_ any metadata on the move, like castling, double-push or en-passant flags. We need to do the merging, but without throwing away our `Move`s