### PR TITLE
Debug tt

### DIFF
--- a/simbelmyne/src/cli/bench.rs
+++ b/simbelmyne/src/cli/bench.rs
@@ -17,8 +17,7 @@ pub fn run_single(fen: &str, depth: usize) {
     let board = fen.parse().unwrap();
     let position = Position::new(board);
     let mut tt = TTable::with_capacity(64);
-    let mut opts = SearchOpts::new();
-    // opts.killers = false;
+    let opts = SearchOpts::ALL;
     let (tc, _handle) = TimeControl::fixed_depth(depth);
     let search = position.search(&mut tt, opts, tc);
 

--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -236,6 +236,7 @@ mod tests {
     use crate::{tests::TEST_POSITIONS, position::Position, search::{SearchOpts, MAX_DEPTH}, time_control::TimeControl, transpositions::TTable};
 
     #[test]
+    #[ignore] // Don't want these running on every single test run
     /// Move ordering should _never_ change the outcome of the search
     fn ordering_tt_move() {
         const DEPTH: usize = 5;
@@ -283,6 +284,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // Don't want these running on every single test run
     /// Move ordering should _never_ change the outcome of the search
     fn ordering_mvv_vla() {
         const DEPTH: usize = 6;
@@ -328,6 +330,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // Don't want these running on every single test run
     /// Move ordering should _never_ change the outcome of the search
     fn ordering_killers() {
         const DEPTH: usize = 5;

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -215,80 +215,98 @@ impl Position {
         }
 
         let mut best_move = Move::NULL;
-        let mut score = Score::MIN + 1;
-        let mut node_type = NodeType::Exact;
+        let mut best_score = Score::MIN + 1;
+        let mut node_type = NodeType::Upper;
+        let mut alpha = alpha;
         let remaining_depth = search.depth - ply;
 
         let tt_entry = tt.probe(self.hash);
 
-        if let Some(entry) = tt_entry {
-            // If the hashes match, but the boards don't, throw a panic
-            assert_eq!(entry.board, self.board);
-
-        }
-
         let tt_usable = tt_entry.is_some_and(|entry| {
-            entry.get_depth() == remaining_depth 
-            && entry.get_type() == NodeType::Exact
+            let tt_depth = entry.get_depth();
+            let tt_type = entry.get_type();
+            let tt_score = entry.get_score();
+
+            tt_depth >= remaining_depth && (
+                tt_type == NodeType::Exact
+                || tt_type == NodeType::Upper && tt_score < alpha
+                || tt_type == NodeType::Lower && tt_score >= beta
+            )
         });
 
         // 1. Can we use an existing TT entry?
         if tt_usable {
             let tt_entry = tt_entry.unwrap();
-            score = tt_entry.get_score();
             best_move = tt_entry.get_move();
+            best_score = tt_entry.get_score();
+            node_type = tt_entry.get_type();
 
             search.tt_hits += 1;
         } else 
 
         // 2. Is this a leaf node?
         if ply == search.depth {
-            score = self.score.total();
+            best_score = self.score.total();
+            node_type = NodeType::Exact;
             search.leaf_nodes += 1;
 
         //3. Recurse over all the child nodes
         } else {
-            let mut alpha = alpha;
-
-            let legal_moves = self.board.legal_moves();
-
             let legal_moves = MovePicker::new(
                 &self,  
-                legal_moves, 
+                self.board.legal_moves(),
                 tt_entry.map(|entry| entry.get_move()),
                 search.killers[ply],
                 search.opts
             );
 
             for mv in legal_moves {
-                let new_score = -self
+                let score = -self
                     .play_move(mv)
                     .negamax(ply + 1, -beta, -alpha, tt, search, tc);
 
-                if new_score > score {
-                    score = new_score;
+                if score > best_score {
+                    best_score = score;
                     best_move = mv;
+                }
+
+                if score > alpha {
+                    alpha = score;
                     node_type = NodeType::Exact;
                 }
 
-                if new_score > alpha {
-                    alpha = new_score;
-                    node_type = NodeType::Upper;
-                }
-
-                if new_score > beta {
+                if score >= beta {
                     node_type = NodeType::Lower;
-                    search.beta_cutoffs[ply] += 1;
-
-                    // Check that it isn't the tt_move, or a capture or a promotion...
-                    if mv.is_quiet() && search.opts.killers { 
-                        search.killers[ply].add(mv);
-                    }
-
                     break;
                 }
             }
         }
+
+        // Additional bookkeeping for cutoffs
+        if node_type == NodeType::Lower {
+            // Increment the cutoff counter
+            search.beta_cutoffs[ply] += 1;
+
+            // If the move was quiet, store it as a killer move
+            if best_move.is_quiet() && search.opts.killers { 
+                search.killers[ply].add(best_move);
+            }
+        }
+
+        // Fail-hard semantics: the score we return is clamped to the
+        // `alpha`-`beta` window. (Note that, if we increased alpha in this node,
+        // then returning `alpha` amounts to returning the actual score.
+        let score = match node_type {
+            NodeType::Upper => {
+                alpha
+            },
+            NodeType::Exact => {
+                best_score
+            },
+            NodeType::Lower => {
+                beta
+            },
+        };
 
         // Store this entry in the TT
         if search.opts.tt {

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -298,7 +298,6 @@ impl Position {
                 score,
                 remaining_depth,
                 node_type,
-                self.board
             ));
         }
 

--- a/simbelmyne/src/transpositions.rs
+++ b/simbelmyne/src/transpositions.rs
@@ -144,6 +144,7 @@ mod tests {
     use crate::search::SearchOpts;
 
     #[test]
+    #[ignore] // Don't want these running on every single test run
     /// Running with or without TT should not affect the outcome of the best move
     fn transposition_table() {
         const DEPTH: usize = 5;

--- a/simbelmyne/src/transpositions.rs
+++ b/simbelmyne/src/transpositions.rs
@@ -1,6 +1,6 @@
 use std::mem::size_of;
 
-use chess::{movegen::moves::Move, board::Board};
+use chess::movegen::moves::Move;
 
 use crate::zobrist::{ZHash, ZKey};
 
@@ -19,7 +19,6 @@ pub struct TTEntry {
     score: i32,          // 32b
     depth: usize,        // 8b
     node_type: NodeType, // 8b
-    pub board: Board,
 } //                    -------- 128b
 
 impl TTEntry {
@@ -29,7 +28,6 @@ impl TTEntry {
         score: i32::MIN,
         depth: 0,
         node_type: NodeType::Exact,
-        board: Board::EMPTY
     };
 
     pub fn new(
@@ -38,9 +36,8 @@ impl TTEntry {
         score: i32, 
         depth: usize, 
         node_type: NodeType,
-        board: Board
     ) -> TTEntry {
-        TTEntry { hash, best_move, score, depth, node_type, board }
+        TTEntry { hash, best_move, score, depth, node_type }
     }
 
 


### PR DESCRIPTION
This one was a bit of a nightmare to debug, but mostly because the fail-soft alpha-beta pruning we were doing makes it really hard to reason about whether the lookup table entries should be treated as upper/lower bounds, etc...

There's still a discrepancy when we allow usage of entries that have a search depth _larger_ than the one we're interested in, but I suppose that only makes sense.