### PR TITLE
Quiescence search

### DIFF
--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -24,9 +24,10 @@ enum Stage {
     Tacticals,
     ScoreQuiets,
     Quiets,
+    Done,
 }
 
-pub struct MovePicker<'a> {
+pub struct MovePicker<'a, const QUIETS: bool = true> {
     stage: Stage,
     position: &'a Position,
     moves: Vec<Move>,
@@ -38,7 +39,7 @@ pub struct MovePicker<'a> {
     opts: SearchOpts
 }
 
-impl<'a> MovePicker<'a> {
+impl<'a, const QUIETS: bool> MovePicker<'a, QUIETS> {
     pub fn new(
         position: &'a Position, 
         moves: Vec<Move>, 
@@ -185,12 +186,12 @@ impl<'a> MovePicker<'a> {
     }
 }
 
-impl<'a> Iterator for MovePicker<'a> {
+impl<'a, const QUIETS: bool> Iterator for MovePicker<'a, QUIETS> {
     type Item = Move;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Check if we've reached the end of the move list
-        if self.index == self.moves.len() {
+        if self.stage == Stage::Done {
             return None;
         }
 
@@ -234,8 +235,10 @@ impl<'a> Iterator for MovePicker<'a> {
 
                 self.index += 1;
                 return tactical;
-            } else {
+            } else if QUIETS{
                 self.stage = Stage::ScoreQuiets;
+            } else {
+                self.stage = Stage::Done;
             }
         }
 
@@ -255,6 +258,8 @@ impl<'a> Iterator for MovePicker<'a> {
 
                 self.index += 1;
                 return quiet;
+            } else {
+                self.stage = Stage::Done;
             }
         }
 

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -209,7 +209,7 @@ impl Position {
         let mut result: Search = Search::new(0, opts);
         let mut depth = 0;
 
-        loop {
+        while depth < MAX_DEPTH && tc.should_continue(depth, result.nodes_visited) {
             depth += 1;
             let mut search = Search::new(depth, opts);
 

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -256,6 +256,17 @@ impl Position {
         let in_check = self.board.in_check();
         search.nodes_visited += 1;
 
+        if ply >= MAX_DEPTH {
+            let score = self.score.total();
+
+            if score <= alpha {
+                return alpha;
+            } else if score > beta {
+                return beta;
+            } else {
+                return score;
+            }
+        }
 
         // Do all the static evaluations first
         // That is, Check whether we can/should assign a score to this node
@@ -273,17 +284,9 @@ impl Position {
             return score;
         }
 
-        // Leaf node?
-        if ply == search.depth {
-            let score = self.score.total();
-
-            if score <= alpha {
-                return alpha;
-            } else if score > beta {
-                return beta;
-            } else {
-                return score;
-            }
+        // If we're in a leaf node, extend with a quiescence search
+        if remaining_depth == 0 {
+            return self.quiescence_search(ply, alpha, beta, search, tc);
         }
 
         // Rule-based draw?
@@ -390,5 +393,61 @@ impl Position {
         }
 
         score
+    }
+
+    fn quiescence_search(
+        &self, 
+        ply: usize,
+        mut alpha: Eval, 
+        beta: Eval, 
+        search: &mut Search,
+        tc: &TimeControl,
+    ) -> Eval {
+        search.nodes_visited += 1;
+        let eval = self.score.total();
+
+        if eval >= beta {
+            return beta
+        }
+
+        if eval > alpha {
+            alpha = eval;
+        }
+
+        if self.board.is_rule_draw() {
+            return 0;
+        }
+
+        if ply >= MAX_DEPTH {
+            return alpha;
+        }
+
+        let legal_moves = MovePicker::new(
+            &self,
+            self.board.legal_moves(),
+            None,
+            Killers::new(),
+            search.opts
+        );
+
+        for mv in legal_moves.captures() {
+            if search.aborted {
+                return Score::MIN;
+            }
+
+            let score = -self
+                .play_move(mv)
+                .quiescence_search(ply + 1, -beta, -alpha, search, tc);
+
+            if score >= beta {
+                return beta;
+            }
+
+            if score > alpha {
+                alpha = score;
+            }
+        }
+
+        alpha
     }
 }

--- a/simbelmyne/src/time_control.rs
+++ b/simbelmyne/src/time_control.rs
@@ -58,9 +58,9 @@ impl TimeControl {
 
         // If no global stop is detected, then respect the chosen time control
         match self.tc {
-            TCType::Depth(max_depth) => depth <= max_depth,
-            TCType::Nodes(max_nodes) => nodes <= max_nodes,
-            TCType::MoveTime(duration) => self.start.elapsed() <= duration,
+            TCType::Depth(max_depth) => depth < max_depth,
+            TCType::Nodes(max_nodes) => nodes < max_nodes,
+            TCType::MoveTime(duration) => self.start.elapsed() < duration,
             TCType::Infinite => true,
         }
     }


### PR DESCRIPTION
Adds basic quiescence search.

Probably could do a whole lot to optimize this. We need to prune this way more agressively (SEE move ordering? Include TT move?) and maybe also store some moves in the TT when it makes sense?