### PR TITLE
History tables

### DIFF
--- a/simbelmyne/src/main.rs
+++ b/simbelmyne/src/main.rs
@@ -13,6 +13,7 @@ mod transpositions;
 mod move_picker;
 mod time_control;
 mod tests;
+mod search_tables;
 
 #[derive(Parser)]
 #[command(author = "Sam Roelants", version = "0.1", about = "A simple perft tool.", long_about = None)]

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -1,4 +1,5 @@
 use crate::search_tables::HistoryTable;
+use crate::search_tables::Killers;
 use std::time::Duration;
 
 use chess::movegen::moves::Move;
@@ -116,6 +117,7 @@ pub struct SearchOpts {
     pub tt_move: bool,
     pub mvv_lva: bool,
     pub killers: bool,
+    pub history_table: bool,
     pub debug: bool,
 }
 
@@ -127,6 +129,7 @@ impl SearchOpts {
             ordering: true,
             mvv_lva: true,
             killers: true,
+            history_table: true,
             debug: true,
         }
     };
@@ -139,6 +142,7 @@ impl SearchOpts {
             ordering: false,
             mvv_lva: false,
             killers: false,
+            history_table: true,
             debug: false,
         }
     };

--- a/simbelmyne/src/search_tables.rs
+++ b/simbelmyne/src/search_tables.rs
@@ -1,0 +1,87 @@
+use std::ops::Deref;
+use chess::square::Square;
+use chess::piece::Piece;
+
+use chess::movegen::moves::Move;
+
+const MAX_KILLERS: usize = 2;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Killers([Move; MAX_KILLERS]);
+
+impl Deref for Killers {
+    type Target = [Move; MAX_KILLERS];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Killers {
+    pub fn new() -> Self {
+        Killers([Move::NULL; MAX_KILLERS])
+    }
+
+    pub fn add(&mut self, mv: Move) {
+        // Make sure we only add distinct moves
+        if !self.contains(&mv) {
+            self.0.rotate_right(1);
+            self.0[0] = mv;
+        }
+    }
+}
+
+pub struct KillersIter {
+    killers: Killers,
+    index: usize,
+}
+
+impl Iterator for KillersIter {
+    type Item = Move;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.killers.len() {
+            return None;
+        }
+
+        let mv = self.killers.0[self.index];
+        self.index += 1;
+
+        if mv == Move::NULL {
+            return None;
+        }
+
+        Some(mv)
+    }
+}
+
+
+impl IntoIterator for Killers {
+    type Item = Move;
+    type IntoIter = KillersIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        KillersIter {
+            killers: self,
+            index: 0,
+        }
+    }
+}
+
+// History table
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct HistoryTable([[i32; Square::COUNT]; Piece::COUNT]);
+
+impl HistoryTable {
+    pub fn new() -> Self {
+        HistoryTable([[0; Square::COUNT]; Piece::COUNT])
+    }
+
+    pub fn increment(&mut self, mv: &Move, piece: &Piece, depth: usize) {
+        self.0[*piece as usize][mv.tgt() as usize] += (depth * depth) as i32;
+    }
+
+    pub fn get(&self, mv: &Move, piece: &Piece) -> i32 {
+        self.0[*piece as usize][mv.tgt() as usize]
+    }
+}


### PR DESCRIPTION
Add simple history tables to improve move ordering.

Doesn't seem like the effect is all that big compared to the PST move ordering we were doing for quiets before that, but hey :shrug:.