### PR TITLE
Pv table

### DIFF
--- a/chessmatch/src/tui.rs
+++ b/chessmatch/src/tui.rs
@@ -77,7 +77,7 @@ impl State {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum Message {
     StartSearch,
     PlayMove(Move),

--- a/shared/src/uci.rs
+++ b/shared/src/uci.rs
@@ -3,7 +3,7 @@ use anyhow::*;
 
 use chess::{movegen::moves::Move, board::Board};
 
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Info {
     pub depth: Option<u8>,
     pub seldepth: Option<u8>,
@@ -14,6 +14,7 @@ pub struct Info {
     pub currmovenumber: Option<u8>,
     pub hashfull: Option<u32>,
     pub nps: Option<u32>,
+    pub pv: Vec<Move>,
 }
 
 impl Display for Info {
@@ -52,6 +53,13 @@ impl Display for Info {
 
         if let Some(nps) = self.nps {
             write!(f, "nps {nps} ")?;
+        }
+
+        if self.pv.len() > 0 {
+            write!(f, "pv ")?;
+            for mv in self.pv.iter() {
+                write!(f, "{mv} ")?;
+            }
         }
 
         std::fmt::Result::Ok(())

--- a/simbelmyne/src/cli/bench.rs
+++ b/simbelmyne/src/cli/bench.rs
@@ -22,7 +22,7 @@ pub fn run_single(fen: &str, depth: usize) {
     opts.mvv_lva = true;
     opts.killers = true;
     opts.history_table = true;
-    opts.debug = false;
+    opts.debug = true;
     let (tc, _handle) = TimeControl::fixed_depth(depth);
     let search = position.search(&mut tt, opts, tc);
 
@@ -31,8 +31,8 @@ pub fn run_single(fen: &str, depth: usize) {
     println!("{:17} {}", "Depth:".green(), depth);
     println!();
 
-    println!("{:17} {}", "Best move:".bright_cyan(), search.best_moves[0]);
-    println!("{:17} {}", "Score:".bright_cyan(), search.scores[0]);
+    println!("{:17} {}", "Best move:".bright_cyan(), search.pv.pv_move());
+    println!("{:17} {}", "Score:".bright_cyan(), search.score);
 
 
     let nodes_visited: usize = search.nodes_visited;

--- a/simbelmyne/src/cli/play/tui.rs
+++ b/simbelmyne/src/cli/play/tui.rs
@@ -215,7 +215,7 @@ fn update(state: &mut State, message: Message) -> Option<Message> {
             state.tt_inserts = inserts;
             state.tt_overwrites = overwrites;
 
-            let new_board = state.current_board().play_move(search.best_moves[0]);
+            let new_board = state.current_board().play_move(search.pv.pv_move());
             state.board_history.push(new_board);
             state.cursor += 1;
 
@@ -278,8 +278,8 @@ fn view(state: &mut State, f: &mut Frame) {
     }
 
 
-    let best_move = state.search.map_or(Move::NULL, |search| search.best_moves[0]);
-    let score = state.search.map_or(0, |search| search.scores[0]);
+    let best_move = state.search.map_or(Move::NULL, |search| search.pv.pv_move());
+    let score = state.search.map_or(0, |search| search.score);
     let nodes_visited = state.search.map_or(0, |search| search.nodes_visited);
     let leaf_nodes = state.search.map_or(0, |search| search.leaf_nodes);
     let beta_cutoffs = state.search.map_or(0, |search| search.beta_cutoffs.iter().sum());

--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -70,13 +70,13 @@ impl<'a> MovePicker<'a> {
         self.moves.len()
     }
 
-    pub fn get_first(&self) -> Move {
-        if let Some(tt_move) = self.tt_move {
-            tt_move
-        } else {
-            self.moves[0]
-        }
-    }
+    // pub fn get_first(&self) -> Move {
+    //     if let Some(tt_move) = self.tt_move {
+    //         tt_move
+    //     } else {
+    //         self.moves[0]
+    //     }
+    // }
 
     pub fn captures(self) -> CapturePicker<'a> {
         CapturePicker(self)

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -22,14 +22,13 @@ const NULL_MOVE_REDUCTION: usize = 3;
 pub struct Search {
     // Information
     pub depth: usize,
+
+    // The principal variation so far
+    pub pv: PVTable,
+
+    // The score for the search
+    pub score: Eval,
     
-    // Search results
-    /// Best move found at each ply of the search
-    pub best_moves: [Move; MAX_DEPTH],
-
-    /// The scores found for said best move, at each ply of the search
-    pub scores: [Eval; MAX_DEPTH],
-
     /// The set of killer moves at a given ply.
     /// Killer moves are quiet moves (non-captures/promotions) that caused a 
     /// beta-cutoff in that ply.
@@ -67,8 +66,8 @@ impl Search {
     pub fn new(depth: usize, opts: SearchOpts) -> Self {
         Self {
             depth,
-            best_moves: [Move::NULL; MAX_DEPTH],
-            scores: [Eval::default(); MAX_DEPTH],
+            pv: PVTable::new(),
+            score: 0,
             killers: [Killers::new(); MAX_DEPTH],
             history_table: HistoryTable::new(),
             nodes_visited: 0,
@@ -91,13 +90,14 @@ impl From<Search> for UciEngineMessage {
         let info = Info {
             depth: Some(value.depth as u8),
             seldepth: Some(value.depth as u8),
-            score: Some(value.scores[0]),
+            score: Some(value.score),
             time: Some(value.duration.as_millis() as u64),
             nps: (1_000 * value.nodes_visited as u32).checked_div(value.duration.as_millis() as u32),
             nodes: Some(value.nodes_visited as u32),
             currmove: None,
             currmovenumber: None,
-            hashfull: None
+            hashfull: None,
+            pv: value.pv.into()
         };
 
         UciEngineMessage::Info(info)
@@ -159,13 +159,11 @@ impl Position {
         while depth < MAX_DEPTH && tc.should_continue(depth, result.nodes_visited) {
             depth += 1;
             let mut search = Search::new(depth, opts);
+            let mut pv = PVTable::new();
 
-            self.negamax(0, Score::MIN, Score::MAX, tt, &mut search, &tc, true);
+            search.score = self.negamax(0, depth, Score::MIN, Score::MAX, tt, &mut pv, &mut search, &tc, false);
             search.duration = tc.elapsed();
-
-            if let Some(entry) = tt.probe(self.hash) {
-                search.best_moves[0] = entry.get_move();
-            }
+            search.pv = pv;
 
             // If we got interrupted in the search, don't store the 
             // half-completed search state. Just break and return the previous
@@ -187,9 +185,11 @@ impl Position {
     fn negamax(
         &self, 
         ply: usize, 
+        mut depth: usize,
         alpha: Eval, 
         beta: Eval, 
         tt: &mut TTable, 
+        pv: &mut PVTable,
         search: &mut Search,
         tc: &TimeControl,
         try_nmp: bool,
@@ -202,10 +202,11 @@ impl Position {
         let mut best_score = Score::MIN + 1;
         let mut node_type = NodeType::Upper;
         let mut alpha = alpha;
-        let remaining_depth = search.depth - ply;
         let tt_entry = tt.probe(self.hash);
         let in_check = self.board.in_check();
         search.nodes_visited += 1;
+        let mut local_pv = PVTable::new();
+        pv.clear();
 
         // Do all the static evaluations first
         // That is, Check whether we can/should assign a score to this node
@@ -223,6 +224,8 @@ impl Position {
         // If we're in a leaf node, extend with a quiescence search
         if remaining_depth == 0 {
             return self.quiescence_search(ply, alpha, beta, search, tc);
+        if depth == 0 {
+            return self.quiescence_search(ply, alpha, beta, pv, search, tc);
         }
 
         // Check the TT table for a result that we can use
@@ -246,12 +249,22 @@ impl Position {
         let should_null_prune = try_nmp
             && ply > 0
             && !in_check
-            && remaining_depth >= NULL_MOVE_REDUCTION + 1;
+            && depth >= NULL_MOVE_REDUCTION + 1;
 
         if should_null_prune {
             let score = -self
                 .play_move(Move::NULL)
-                .negamax(ply + 1 + NULL_MOVE_REDUCTION, -beta, -beta + 1, tt, search, tc, false);
+                .negamax(
+                    ply + 1, 
+                    depth - 1 - NULL_MOVE_REDUCTION, 
+                    -beta, 
+                    -beta + 1, 
+                    tt, 
+                    &mut PVTable::new(), 
+                    search, 
+                    tc, 
+                    false
+                );
 
             if score >= beta {
                 return beta;
@@ -286,21 +299,22 @@ impl Position {
 
             let score = -self
                 .play_move(mv)
-                .negamax(ply + 1, -beta, -alpha, tt, search, tc, true);
+                .negamax(ply + 1, depth - 1, -beta, -alpha, tt, &mut local_pv, search, tc, true);
 
             if score > best_score {
                 best_score = score;
                 best_move = mv;
             }
 
-            if alpha <= score {
+            if alpha < score {
                 alpha = score;
                 node_type = NodeType::Exact;
+                pv.add_to_front(mv, &local_pv);
             }
 
             if beta <= score {
                 let piece = self.board.get_at(mv.src()).unwrap();
-                search.history_table.increment(&mv, piece, remaining_depth);
+                search.history_table.increment(&mv, piece, depth);
                 node_type = NodeType::Lower;
                 break;
             }
@@ -315,19 +329,6 @@ impl Position {
             NodeType::Lower => beta,
         };
 
-        // If, for some reason, we haven't actually updated the best move at this
-        // point (i.e., it's still an uninitialized NULL move, then choose the
-        // first legal move as a backup move;
-        if best_move == Move::NULL {
-            best_move = legal_moves.get_first()
-        }
-
-        // Propagate up the results
-        if score > search.scores[ply] {
-            search.best_moves[ply] = best_move;
-            search.scores[ply] = score;
-        }
-
         if node_type == NodeType::Lower 
             && best_move.is_quiet() 
             && search.opts.killers { 
@@ -340,7 +341,7 @@ impl Position {
                 self.hash,
                 best_move,
                 score,
-                remaining_depth,
+                depth,
                 node_type,
             ));
         }
@@ -353,10 +354,12 @@ impl Position {
         ply: usize,
         mut alpha: Eval, 
         beta: Eval, 
+        pv: &mut PVTable,
         search: &mut Search,
         tc: &TimeControl,
     ) -> Eval {
         search.nodes_visited += 1;
+        let mut local_pv = PVTable::new();
 
         if self.board.is_rule_draw() || self.is_repetition() {
             return 0;
@@ -372,7 +375,7 @@ impl Position {
             return beta
         }
 
-        if eval > alpha {
+        if alpha < eval {
             alpha = eval;
         }
 
@@ -392,14 +395,15 @@ impl Position {
 
             let score = -self
                 .play_move(mv)
-                .quiescence_search(ply + 1, -beta, -alpha, search, tc);
+                .quiescence_search(ply + 1, -beta, -alpha, &mut local_pv , search, tc);
 
             if score >= beta {
                 return beta;
             }
 
-            if score > alpha {
+            if alpha < score {
                 alpha = score;
+                pv.add_to_front(mv, &local_pv);
             }
         }
 

--- a/simbelmyne/src/search_tables.rs
+++ b/simbelmyne/src/search_tables.rs
@@ -1,10 +1,65 @@
+use std::fmt::Display;
 use std::ops::Deref;
 use chess::square::Square;
 use chess::piece::Piece;
 
 use chess::movegen::moves::Move;
 
+use crate::search::MAX_DEPTH;
+
 const MAX_KILLERS: usize = 2;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct PVTable {
+    pv: [Move; MAX_DEPTH],
+    pub len: usize,
+}
+
+impl PVTable {
+    pub fn new() -> Self {
+        Self {
+            pv: [Move::NULL; MAX_DEPTH],
+            len: 0
+        }
+    }
+
+    pub fn add_to_front(&mut self, mv: Move, existing: &Self) {
+        self.len = existing.len + 1;
+        self.pv[0] = mv;
+        self.pv[1..=self.len].copy_from_slice(&existing.pv[0..=existing.len]);
+    }
+
+    pub fn moves(&self) -> &[Move] {
+        &self.pv[..self.len]
+    }
+
+    pub fn pv_move(&self) -> Move {
+        self.moves()[0]
+    }
+}
+
+impl Display for PVTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "pv")?;
+
+        for (i, mv) in self.pv.iter().enumerate() {
+            write!(f, " {mv}")?;
+
+            if i == self.len {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl From<PVTable> for Vec<Move> {
+    fn from(value: PVTable) -> Self {
+        value.pv[..value.len].to_vec()
+    }
+}
+
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Killers([Move; MAX_KILLERS]);

--- a/simbelmyne/src/search_tables.rs
+++ b/simbelmyne/src/search_tables.rs
@@ -12,7 +12,7 @@ const MAX_KILLERS: usize = 2;
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct PVTable {
     pv: [Move; MAX_DEPTH],
-    pub len: usize,
+    len: usize,
 }
 
 impl PVTable {
@@ -21,6 +21,10 @@ impl PVTable {
             pv: [Move::NULL; MAX_DEPTH],
             len: 0
         }
+    }
+
+    pub fn clear(&mut self) {
+        self.len = 0;
     }
 
     pub fn add_to_front(&mut self, mv: Move, existing: &Self) {

--- a/simbelmyne/src/tests/mod.rs
+++ b/simbelmyne/src/tests/mod.rs
@@ -184,15 +184,15 @@ pub fn run_test_suite(opts1: SearchOpts, opts2: SearchOpts, depth: usize) {
         let (tc, _) = TimeControl::fixed_depth(depth);
 
         let search1 = position.search(&mut tt, opts1, tc);
-        let best_move1 = search1.best_moves[0];
-        let score1 = search1.scores[0];
+        let best_move1 = search1.pv.pv_move();
+        let score1 = search1.score;
 
         let mut tt = TTable::with_capacity(64);
         let (tc, _) = TimeControl::fixed_depth(depth);
 
         let search2 = position.search(&mut tt, opts2, tc);
-        let best_move2 = search2.best_moves[0];
-        let score2 = search2.scores[0];
+        let best_move2 = search2.pv.pv_move();
+        let score2 = search2.score;
 
         // We'd expect to get back the same move, _or_, if not, the moves should
         // have the same score

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -102,8 +102,9 @@ impl SearchThread {
 
                     let mut tt = TTable::with_capacity(64);
                     let opts = SearchOpts::ALL;
+                    // opts.killers = false;
                     let search = self.position.search(&mut tt, opts, tc);
-                    let mv = search.best_moves[0];
+                    let mv = search.pv.pv_move();
                     println!("bestmove {mv}");
                 },
 


### PR DESCRIPTION
Add an explicit pv table, rather than passing a `best_moves` and `scores` array around, because it was a nightmare to reason about.

To be fair, this was also a nightmare to reason about.

Chess is hard.