### PR TITLE
Add BareMove

### DIFF
--- a/chess/src/movegen/legal_moves.rs
+++ b/chess/src/movegen/legal_moves.rs
@@ -20,6 +20,8 @@ use crate::movegen::attack_boards::BETWEEN;
 use crate::movegen::moves::Move;
 use crate::piece::PieceType;
 
+use super::moves::BareMove;
+
 impl Board {
     /// Find all the legal moves for the current board state
     pub fn legal_moves(&self) -> Vec<Move> {
@@ -195,9 +197,9 @@ impl Board {
         legal_moves
     }
 
-    pub fn find_move(&self, mv: Move) -> Option<Move> {
+    pub fn find_move(&self, bare: BareMove) -> Option<Move> {
         let legals = self.legal_moves();
-        legals.into_iter().find(|legal| legal.weak_match(mv))
+        legals.into_iter().find(|legal| legal.eq(&bare))
     }
 }
 

--- a/chessmatch/src/engine.rs
+++ b/chessmatch/src/engine.rs
@@ -93,7 +93,7 @@ impl Engine {
     }
 
     pub async fn set_pos(&mut self, board: Board) {
-        self.send(UciClientMessage::Position(board)).await.unwrap();
+        self.send(UciClientMessage::Position(board, vec![])).await.unwrap();
     }
 
     pub async fn go(&mut self) {

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -90,8 +90,11 @@ impl SearchThread {
 
                 UciClientMessage::Debug(debug) => self.debug = debug,
 
-                UciClientMessage::Position(board) => {
-                    self.position = Position::new(board);
+                UciClientMessage::Position(board, moves) => {
+                    self.position = moves.into_iter().fold(
+                        Position::new(board),
+                        |position, mv| position.play_bare_move(mv)
+                    );
                 },
 
                 UciClientMessage::Go(tc) => {


### PR DESCRIPTION
Often, we parse moves we get over UCI from algebraic strings. These are missing a lot of metadata that's encoded in our Move type.

Adding a BareMove type that acts as an intermediary. It can be compared for equality with a Move, and it can be played to a board position just fine (panics if the move is illegal, though!), and parsed/printed from/to algebraic like regular moves.