### PR TITLE
Search struct refactor

### DIFF
--- a/chessmatch/src/components/engine_info.rs
+++ b/chessmatch/src/components/engine_info.rs
@@ -15,7 +15,7 @@ pub struct EngineInfo {
     pub nodes_visited: u32,
     pub score: i32,
     pub nps: u32,
-    pub hashfull: u32,
+    pub hashfull: f32,
 }
 
 impl Widget for EngineInfo {
@@ -88,7 +88,7 @@ impl Widget for EngineInfo {
 
         let hashfull = Row::new(vec![
             Cell::from("Hashfull").blue(),
-            Cell::from(format!("{}%", self.hashfull / 10)),
+            Cell::from(format!("{}%", self.hashfull / 10.0)),
         ]);
 
         let style = if self.active { 

--- a/chessmatch/src/components/engine_info.rs
+++ b/chessmatch/src/components/engine_info.rs
@@ -15,7 +15,7 @@ pub struct EngineInfo {
     pub nodes_visited: u32,
     pub score: i32,
     pub nps: u32,
-    pub hashfull: f32,
+    pub hashfull: u32,
 }
 
 impl Widget for EngineInfo {
@@ -88,7 +88,7 @@ impl Widget for EngineInfo {
 
         let hashfull = Row::new(vec![
             Cell::from("Hashfull").blue(),
-            Cell::from(format!("{}%", self.hashfull / 10.0)),
+            Cell::from(format!("{}%", self.hashfull / 10)),
         ]);
 
         let style = if self.active { 

--- a/chessmatch/src/engine.rs
+++ b/chessmatch/src/engine.rs
@@ -5,7 +5,7 @@ use tokio::process::{Command, ChildStdout};
 use tokio::io::{BufReader,  AsyncWriteExt, AsyncBufReadExt};
 use serde::Deserialize;
 
-use shared::uci::{UciClientMessage, UciEngineMessage,  SearchReport, TCType};
+use shared::uci::{UciClientMessage, UciEngineMessage,  SearchInfo, TCType};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct EngineConfig {
@@ -23,7 +23,7 @@ pub struct Engine {
     stdout: tokio::io::BufReader<ChildStdout>,
     pub config: EngineConfig,
     pub tc: TCType,
-    pub search_info: SearchReport,
+    pub search_info: SearchInfo,
 }
 
 impl Engine {
@@ -56,7 +56,7 @@ impl Engine {
             stdout: BufReader::new(stdout),
             config: config.clone(),
             tc,
-            search_info: SearchReport::default()
+            search_info: SearchInfo::default()
         }
     }
 
@@ -100,7 +100,7 @@ impl Engine {
         self.send(UciClientMessage::Go(self.tc)).await.unwrap();
     }
 
-    pub fn update_info(&mut self, search_info: SearchReport) {
+    pub fn update_info(&mut self, search_info: SearchInfo) {
         if search_info.depth.is_some() {
             self.search_info.depth = search_info.depth;
         }

--- a/chessmatch/src/engine.rs
+++ b/chessmatch/src/engine.rs
@@ -5,7 +5,7 @@ use tokio::process::{Command, ChildStdout};
 use tokio::io::{BufReader,  AsyncWriteExt, AsyncBufReadExt};
 use serde::Deserialize;
 
-use shared::uci::{UciClientMessage, UciEngineMessage,  Info, TCType};
+use shared::uci::{UciClientMessage, UciEngineMessage,  SearchReport, TCType};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct EngineConfig {
@@ -23,7 +23,7 @@ pub struct Engine {
     stdout: tokio::io::BufReader<ChildStdout>,
     pub config: EngineConfig,
     pub tc: TCType,
-    pub search_info: Info,
+    pub search_info: SearchReport,
 }
 
 impl Engine {
@@ -56,7 +56,7 @@ impl Engine {
             stdout: BufReader::new(stdout),
             config: config.clone(),
             tc,
-            search_info: Info::default()
+            search_info: SearchReport::default()
         }
     }
 
@@ -100,7 +100,7 @@ impl Engine {
         self.send(UciClientMessage::Go(self.tc)).await.unwrap();
     }
 
-    pub fn update_info(&mut self, search_info: Info) {
+    pub fn update_info(&mut self, search_info: SearchReport) {
         if search_info.depth.is_some() {
             self.search_info.depth = search_info.depth;
         }

--- a/chessmatch/src/tui.rs
+++ b/chessmatch/src/tui.rs
@@ -6,7 +6,7 @@ use ratatui::{Terminal, prelude::CrosstermBackend};
 use tokio::select;
 use tokio_stream::StreamExt;
 use shared::uci::UciEngineMessage;
-use shared::uci::Info;
+use shared::uci::SearchReport;
 
 use crate::{engine::{Config, Engine}, components::view};
 
@@ -81,7 +81,7 @@ impl State {
 enum Message {
     StartSearch,
     PlayMove(Move),
-    UpdateInfo(Info),
+    UpdateInfo(SearchReport),
     TogglePause,
     GameFinished(GameResult),
     NewGame,

--- a/chessmatch/src/tui.rs
+++ b/chessmatch/src/tui.rs
@@ -6,7 +6,7 @@ use ratatui::{Terminal, prelude::CrosstermBackend};
 use tokio::select;
 use tokio_stream::StreamExt;
 use shared::uci::UciEngineMessage;
-use shared::uci::SearchReport;
+use shared::uci::SearchInfo;
 
 use crate::{engine::{Config, Engine}, components::view};
 
@@ -77,11 +77,11 @@ impl State {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 enum Message {
     StartSearch,
     PlayMove(Move),
-    UpdateInfo(SearchReport),
+    UpdateInfo(SearchInfo),
     TogglePause,
     GameFinished(GameResult),
     NewGame,

--- a/shared/src/uci.rs
+++ b/shared/src/uci.rs
@@ -4,7 +4,7 @@ use anyhow::*;
 use chess::{movegen::moves::{Move, BareMove}, board::Board};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Info {
+pub struct SearchReport {
     pub depth: Option<u8>,
     pub seldepth: Option<u8>,
     pub time: Option<u64>,
@@ -17,7 +17,7 @@ pub struct Info {
     pub pv: Vec<Move>,
 }
 
-impl Display for Info {
+impl Display for SearchReport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(depth) = self.depth {
             write!(f, "depth {depth} ")?;
@@ -66,11 +66,11 @@ impl Display for Info {
     }
 }
 
-impl FromStr for Info {
+impl FromStr for SearchReport {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> anyhow::Result<Self> {
-        let mut info = Info::default();
+        let mut info = SearchReport::default();
         let mut parts = s.split_whitespace();
         
         while let Some(info_type) = parts.next() {
@@ -459,7 +459,7 @@ pub enum UciEngineMessage {
     UciOk,
     ReadyOk,
     BestMove(Move),
-    Info(Info)
+    Info(SearchReport)
 }
 
 impl FromStr for UciEngineMessage {

--- a/shared/src/uci.rs
+++ b/shared/src/uci.rs
@@ -3,8 +3,8 @@ use anyhow::*;
 
 use chess::{movegen::moves::{Move, BareMove}, board::Board};
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct SearchReport {
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SearchInfo {
     pub depth: Option<u8>,
     pub seldepth: Option<u8>,
     pub time: Option<u64>,
@@ -12,12 +12,12 @@ pub struct SearchReport {
     pub score: Option<i32>,
     pub currmove: Option<Move>,
     pub currmovenumber: Option<u8>,
-    pub hashfull: Option<u32>,
+    pub hashfull: Option<f32>,
     pub nps: Option<u32>,
     pub pv: Vec<Move>,
 }
 
-impl Display for SearchReport {
+impl Display for SearchInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(depth) = self.depth {
             write!(f, "depth {depth} ")?;
@@ -66,11 +66,11 @@ impl Display for SearchReport {
     }
 }
 
-impl FromStr for SearchReport {
+impl FromStr for SearchInfo {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> anyhow::Result<Self> {
-        let mut info = SearchReport::default();
+        let mut info = SearchInfo::default();
         let mut parts = s.split_whitespace();
         
         while let Some(info_type) = parts.next() {
@@ -459,7 +459,7 @@ pub enum UciEngineMessage {
     UciOk,
     ReadyOk,
     BestMove(Move),
-    Info(SearchReport)
+    Info(SearchInfo)
 }
 
 impl FromStr for UciEngineMessage {

--- a/shared/src/uci.rs
+++ b/shared/src/uci.rs
@@ -12,7 +12,7 @@ pub struct SearchInfo {
     pub score: Option<i32>,
     pub currmove: Option<Move>,
     pub currmovenumber: Option<u8>,
-    pub hashfull: Option<f32>,
+    pub hashfull: Option<u32>,
     pub nps: Option<u32>,
     pub pv: Vec<Move>,
 }

--- a/simbelmyne/src/cli/bench.rs
+++ b/simbelmyne/src/cli/bench.rs
@@ -1,6 +1,6 @@
 use colored::Colorize;
 
-use crate::{position::Position, transpositions::TTable, search::SearchOpts, time_control::TimeControl};
+use crate::{position::Position, transpositions::TTable, time_control::TimeControl};
 
 use super::presets::Preset;
 pub fn run_bench(depth: usize, fen: Option<String>) {
@@ -17,14 +17,8 @@ pub fn run_single(fen: &str, depth: usize) {
     let board = fen.parse().unwrap();
     let position = Position::new(board);
     let mut tt = TTable::with_capacity(64);
-    let mut opts = SearchOpts::ALL;
-    opts.tt_move = true;
-    opts.mvv_lva = true;
-    opts.killers = true;
-    opts.history_table = true;
-    opts.debug = true;
     let (tc, _handle) = TimeControl::fixed_depth(depth);
-    let search = position.search(&mut tt, opts, tc);
+    let search = position.search(&mut tt, tc);
 
     println!("{board}");
     println!("{:17} {}", "FEN:".green(), fen);

--- a/simbelmyne/src/cli/bench.rs
+++ b/simbelmyne/src/cli/bench.rs
@@ -26,16 +26,16 @@ pub fn run_single(fen: &str, depth: usize) {
     println!();
 
     println!("{:17} {}", "Best move:".bright_cyan(), search.pv[0]);
-    println!("{:17} {}", "Score:".bright_cyan(), search.score.unwrap_or_default());
+    println!("{:17} {}", "Score:".bright_cyan(), search.score);
 
 
-    let nodes_visited: u32 = search.nodes.unwrap_or_default();
+    let nodes_visited: u32 = search.nodes;
     println!("{:17} {}", "Nodes visited:".blue(), nodes_visited);
 
-    let time_spent = search.time.unwrap_or_default();
+    let time_spent = search.duration.as_millis();
     println!("{:17} {}ms", "Duration:".red(), time_spent);
 
-    let knps = search.nps.unwrap_or_default() / 1000;
+    let knps = 1000 * search.nodes / time_spent as u32;
     println!("{:17} {}knps", "knps:".red(), knps);
 
     // Branching factors

--- a/simbelmyne/src/cli/bench.rs
+++ b/simbelmyne/src/cli/bench.rs
@@ -38,9 +38,6 @@ pub fn run_single(fen: &str, depth: usize) {
     let nodes_visited: usize = search.nodes_visited;
     println!("{:17} {}", "Nodes visited:".blue(), nodes_visited);
 
-    let leaf_nodes = search.leaf_nodes;
-    println!("{:17} {}", "Leaf nodes:".blue(), leaf_nodes);
-
     let beta_cutoffs: usize = search.beta_cutoffs.iter().sum();
     println!("{:17} {}", "Beta cutoffs:".blue(), beta_cutoffs);
 

--- a/simbelmyne/src/cli/bench.rs
+++ b/simbelmyne/src/cli/bench.rs
@@ -38,9 +38,6 @@ pub fn run_single(fen: &str, depth: usize) {
     let nodes_visited: usize = search.nodes_visited;
     println!("{:17} {}", "Nodes visited:".blue(), nodes_visited);
 
-    let beta_cutoffs: usize = search.beta_cutoffs.iter().sum();
-    println!("{:17} {}", "Beta cutoffs:".blue(), beta_cutoffs);
-
     let time_spent = search.duration.as_millis();
     println!("{:17} {}ms", "Duration:".red(), time_spent);
 

--- a/simbelmyne/src/cli/bench.rs
+++ b/simbelmyne/src/cli/bench.rs
@@ -25,17 +25,17 @@ pub fn run_single(fen: &str, depth: usize) {
     println!("{:17} {}", "Depth:".green(), depth);
     println!();
 
-    println!("{:17} {}", "Best move:".bright_cyan(), search.pv.pv_move());
-    println!("{:17} {}", "Score:".bright_cyan(), search.score);
+    println!("{:17} {}", "Best move:".bright_cyan(), search.pv[0]);
+    println!("{:17} {}", "Score:".bright_cyan(), search.score.unwrap_or_default());
 
 
-    let nodes_visited: usize = search.nodes_visited;
+    let nodes_visited: u32 = search.nodes.unwrap_or_default();
     println!("{:17} {}", "Nodes visited:".blue(), nodes_visited);
 
-    let time_spent = search.duration.as_millis();
+    let time_spent = search.time.unwrap_or_default();
     println!("{:17} {}ms", "Duration:".red(), time_spent);
 
-    let knps = nodes_visited / if time_spent > 0 { time_spent as usize } else { 1 };
+    let knps = search.nps.unwrap_or_default() / 1000;
     println!("{:17} {}knps", "knps:".red(), knps);
 
     // Branching factors

--- a/simbelmyne/src/cli/bench.rs
+++ b/simbelmyne/src/cli/bench.rs
@@ -54,7 +54,6 @@ pub fn run_single(fen: &str, depth: usize) {
     // TT info
     println!("{:17} {}%", "TT occupancy".purple(), tt.occupancy());
     println!("{:17} {}", "TT inserts".purple(), tt.inserts());
-    println!("{:17} {}", "TT hits".purple(), search.tt_hits);
 
     println!("\n");
 }

--- a/simbelmyne/src/cli/play/info_view.rs
+++ b/simbelmyne/src/cli/play/info_view.rs
@@ -15,7 +15,6 @@ pub struct InfoView {
     pub duration: Duration,
     pub score: i32,
     pub best_move: Move,
-    pub tt_hits: usize,
     pub tt_occupancy: usize,
     pub tt_inserts: usize,
     pub tt_overwrites: usize,
@@ -73,11 +72,6 @@ impl Widget for InfoView {
             Cell::from(format!("{}", self.score)),
         ]);
 
-        let tt_hits = Row::new(vec![
-            Cell::from("TT Hits").blue(),
-            Cell::from(format!("{}", self.tt_hits)),
-        ]);
-
         let tt_occ = Row::new(vec![
             Cell::from("TT occupancy").blue(),
             Cell::from(format!("{}%", self.tt_occupancy)),
@@ -103,7 +97,6 @@ impl Widget for InfoView {
             search_speed,
             best_move,
             score,
-            tt_hits,
             tt_occ,
             tt_inserts,
             tt_overwrites,

--- a/simbelmyne/src/cli/play/info_view.rs
+++ b/simbelmyne/src/cli/play/info_view.rs
@@ -11,7 +11,6 @@ use ratatui::{
 pub struct InfoView {
     pub depth: usize,
     pub nodes_visited: usize,
-    pub leaf_nodes: usize,
     pub beta_cutoffs: usize,
     pub duration: Duration,
     pub score: i32,
@@ -34,11 +33,6 @@ impl Widget for InfoView {
             Cell::from(format!("{}", self.nodes_visited)),
         ]);
 
-        let leaf_nodes = Row::new(vec![
-            Cell::from("Leaf nodes").blue(),
-            Cell::from(format!("{}", self.leaf_nodes)),
-        ]);
-
         let beta_cutoffs = Row::new(vec![
             Cell::from("Beta cutoffs").blue(),
             Cell::from(format!("{}", self.beta_cutoffs)),
@@ -47,22 +41,6 @@ impl Widget for InfoView {
         let branching_factor = Row::new(vec![
             Cell::from("Branching Factor").blue(),
             Cell::from(format!("{:.2}", (self.nodes_visited as f32).powf(1.0/ self.depth as f32))),
-        ]);
-
-        let std_branching_factor = Row::new(vec![
-            Cell::from("(Alt) Branching Factor").blue(),
-            Cell::from(
-                format!("{:.2}",
-                if self.nodes_visited == self.leaf_nodes {
-                    0.0 
-                } else { 
-                    (self.nodes_visited - 1) as f32 / (self.nodes_visited - self.leaf_nodes) as f32
-                }))
-            ]);
-
-        let third_branching_factor = Row::new(vec![
-            Cell::from("3rd Branching Factor").blue(),
-            Cell::from(format!("{:.2}", (self.leaf_nodes as f32).powf(1.0/ (self.depth as f32 - 1.0)))),
         ]);
 
         let duration = self.duration.as_millis();
@@ -119,11 +97,8 @@ impl Widget for InfoView {
         let table = Table::new(vec![
             search_depth,
             nodes_visited,
-            leaf_nodes,
             beta_cutoffs,
             branching_factor,
-            std_branching_factor,
-            third_branching_factor,
             duration,
             search_speed,
             best_move,

--- a/simbelmyne/src/cli/play/info_view.rs
+++ b/simbelmyne/src/cli/play/info_view.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use chess::movegen::moves::Move;
 
 use ratatui::{
@@ -10,8 +8,8 @@ use ratatui::{
 
 pub struct InfoView {
     pub depth: usize,
-    pub nodes_visited: usize,
-    pub duration: Duration,
+    pub nodes_visited: u32,
+    pub duration: u64,
     pub score: i32,
     pub best_move: Move,
     pub tt_occupancy: usize,
@@ -36,20 +34,19 @@ impl Widget for InfoView {
             Cell::from(format!("{:.2}", (self.nodes_visited as f32).powf(1.0/ self.depth as f32))),
         ]);
 
-        let duration = self.duration.as_millis();
-        let duration = if duration == 0 { 1 } else { duration };
+        let duration = if self.duration == 0 { 1 } else { self.duration };
 
         let search_speed = Row::new(vec![
             Cell::from("Search speed").blue(),
             Cell::from(format!(
                 "{}knps", 
-                self.nodes_visited / duration as usize
+                self.nodes_visited / duration as u32
             )),
         ]);
 
         let duration = Row::new(vec![
             Cell::from("Duration").blue(),
-            Cell::from(format!("{}ms", self.duration.as_millis())),
+            Cell::from(format!("{}ms", self.duration)),
         ]);
 
 

--- a/simbelmyne/src/cli/play/info_view.rs
+++ b/simbelmyne/src/cli/play/info_view.rs
@@ -11,7 +11,6 @@ use ratatui::{
 pub struct InfoView {
     pub depth: usize,
     pub nodes_visited: usize,
-    pub beta_cutoffs: usize,
     pub duration: Duration,
     pub score: i32,
     pub best_move: Move,
@@ -30,11 +29,6 @@ impl Widget for InfoView {
         let nodes_visited = Row::new(vec![
             Cell::from("Nodes visited").blue(),
             Cell::from(format!("{}", self.nodes_visited)),
-        ]);
-
-        let beta_cutoffs = Row::new(vec![
-            Cell::from("Beta cutoffs").blue(),
-            Cell::from(format!("{}", self.beta_cutoffs)),
         ]);
 
         let branching_factor = Row::new(vec![
@@ -91,7 +85,6 @@ impl Widget for InfoView {
         let table = Table::new(vec![
             search_depth,
             nodes_visited,
-            beta_cutoffs,
             branching_factor,
             duration,
             search_speed,

--- a/simbelmyne/src/cli/play/tui.rs
+++ b/simbelmyne/src/cli/play/tui.rs
@@ -281,7 +281,6 @@ fn view(state: &mut State, f: &mut Frame) {
     let best_move = state.search.map_or(Move::NULL, |search| search.pv.pv_move());
     let score = state.search.map_or(0, |search| search.score);
     let nodes_visited = state.search.map_or(0, |search| search.nodes_visited);
-    let leaf_nodes = state.search.map_or(0, |search| search.leaf_nodes);
     let beta_cutoffs = state.search.map_or(0, |search| search.beta_cutoffs.iter().sum());
     let tt_hits = state.search.map_or(0, |search| search.tt_hits);
     let duration = state.search.map_or(Duration::default(), |search| search.duration);
@@ -290,7 +289,6 @@ fn view(state: &mut State, f: &mut Frame) {
         depth: state.search_depth,
         duration,
         nodes_visited,
-        leaf_nodes,
         beta_cutoffs,
         score,
         best_move,

--- a/simbelmyne/src/cli/play/tui.rs
+++ b/simbelmyne/src/cli/play/tui.rs
@@ -17,7 +17,7 @@ use ratatui::style::Style;
 use ratatui::style;
 use tui_input::{self, backend::crossterm::EventHandler};
 
-use crate::{search::{Search, DEFAULT_OPTS}, transpositions::TTable, time_control::TimeControl};
+use crate::{search::Search, transpositions::TTable, time_control::TimeControl};
 use crate::position::Position;
 
 use shared::components::{board_view::BoardView, centered};
@@ -429,7 +429,7 @@ pub fn init_tui(fen: String, depth: usize) -> anyhow::Result<()> {
                 std::thread::spawn(move || {
                     let mut tt = thread_tt.lock().unwrap();
                     let (tc, _handle) = TimeControl::fixed_depth(depth);
-                    let search = Position::new(board).search(&mut tt, DEFAULT_OPTS, tc);
+                    let search = Position::new(board).search(&mut tt, tc);
 
                     queue.lock().unwrap()
                         .push_back(Message::ReturnSearch(

--- a/simbelmyne/src/cli/play/tui.rs
+++ b/simbelmyne/src/cli/play/tui.rs
@@ -281,14 +281,12 @@ fn view(state: &mut State, f: &mut Frame) {
     let best_move = state.search.map_or(Move::NULL, |search| search.pv.pv_move());
     let score = state.search.map_or(0, |search| search.score);
     let nodes_visited = state.search.map_or(0, |search| search.nodes_visited);
-    let beta_cutoffs = state.search.map_or(0, |search| search.beta_cutoffs.iter().sum());
     let duration = state.search.map_or(Duration::default(), |search| search.duration);
 
     let info_view = InfoView {
         depth: state.search_depth,
         duration,
         nodes_visited,
-        beta_cutoffs,
         score,
         best_move,
         tt_occupancy: state.tt_occupancy,

--- a/simbelmyne/src/cli/play/tui.rs
+++ b/simbelmyne/src/cli/play/tui.rs
@@ -20,7 +20,7 @@ use tui_input::{self, backend::crossterm::EventHandler};
 use crate::{transpositions::TTable, time_control::TimeControl};
 use crate::position::Position;
 
-use shared::{components::{board_view::BoardView, centered}, uci::SearchReport};
+use shared::{components::{board_view::BoardView, centered}, uci::SearchInfo};
 use super::{input_view::InputView, info_view::InfoView};
 
 pub struct State {
@@ -37,7 +37,7 @@ pub struct State {
     error: Option<String>,
 
     search_depth: usize,
-    search:  Option<SearchReport>,
+    search:  Option<SearchInfo>,
 
     input: tui_input::Input,
     input_mode: InputMode,
@@ -84,7 +84,7 @@ impl State {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 enum Message {
     NormalMode,
     InsertMode,
@@ -94,7 +94,7 @@ enum Message {
     Input(KeyEvent),
     PlayMove(Move),
     SearchOpponentMove,
-    ReturnSearch(SearchReport, usize, usize, usize),
+    ReturnSearch(SearchInfo, usize, usize, usize),
     GoBack,
     GoBackToStart,
     GoForward,
@@ -436,8 +436,8 @@ pub fn init_tui(fen: String, depth: usize) -> anyhow::Result<()> {
 
                     queue.lock().unwrap()
                         .push_back(Message::ReturnSearch(
-                            search,
-                            tt.occupancy(), 
+                            (&search).into(),
+                            tt.occupancy() as usize, 
                             tt.inserts(), 
                             tt.overwrites()
                         ));

--- a/simbelmyne/src/cli/play/tui.rs
+++ b/simbelmyne/src/cli/play/tui.rs
@@ -17,10 +17,10 @@ use ratatui::style::Style;
 use ratatui::style;
 use tui_input::{self, backend::crossterm::EventHandler};
 
-use crate::{search::Search, transpositions::TTable, time_control::TimeControl};
+use crate::{transpositions::TTable, time_control::TimeControl};
 use crate::position::Position;
 
-use shared::components::{board_view::BoardView, centered};
+use shared::{components::{board_view::BoardView, centered}, uci::SearchReport};
 use super::{input_view::InputView, info_view::InfoView};
 
 pub struct State {
@@ -37,7 +37,7 @@ pub struct State {
     error: Option<String>,
 
     search_depth: usize,
-    search:  Option<Search>,
+    search:  Option<SearchReport>,
 
     input: tui_input::Input,
     input_mode: InputMode,
@@ -94,7 +94,7 @@ enum Message {
     Input(KeyEvent),
     PlayMove(Move),
     SearchOpponentMove,
-    ReturnSearch(Search, usize, usize, usize),
+    ReturnSearch(SearchReport, usize, usize, usize),
     GoBack,
     GoBackToStart,
     GoForward,
@@ -210,12 +210,12 @@ fn update(state: &mut State, message: Message) -> Option<Message> {
         },
 
         Message::ReturnSearch(search, occupancy, inserts, overwrites) => {
+            let new_board = state.current_board().play_move(search.pv[0]);
+
             state.search = Some(search);
             state.tt_occupancy = occupancy;
             state.tt_inserts = inserts;
             state.tt_overwrites = overwrites;
-
-            let new_board = state.current_board().play_move(search.pv.pv_move());
             state.board_history.push(new_board);
             state.cursor += 1;
 
@@ -278,23 +278,26 @@ fn view(state: &mut State, f: &mut Frame) {
     }
 
 
-    let best_move = state.search.map_or(Move::NULL, |search| search.pv.pv_move());
-    let score = state.search.map_or(0, |search| search.score);
-    let nodes_visited = state.search.map_or(0, |search| search.nodes_visited);
-    let duration = state.search.map_or(Duration::default(), |search| search.duration);
+    // let search = state.search.clone();
+    if let Some(search) = &state.search {
+        let score = search.score.unwrap_or_default();
+        let nodes_visited = search.nodes.unwrap_or_default();
+        let duration = search.time.unwrap_or_default();
+        let best_move = *search.pv.first().unwrap_or(&Move::NULL);
 
-    let info_view = InfoView {
-        depth: state.search_depth,
-        duration,
-        nodes_visited,
-        score,
-        best_move,
-        tt_occupancy: state.tt_occupancy,
-        tt_inserts: state.tt_inserts,
-        tt_overwrites: state.tt_overwrites,
-    };
+        let info_view = InfoView {
+            depth: state.search_depth,
+            duration,
+            nodes_visited,
+            score,
+            best_move,
+            tt_occupancy: state.tt_occupancy,
+            tt_inserts: state.tt_inserts,
+            tt_overwrites: state.tt_overwrites,
+        };
 
-    f.render_widget(info_view, layout_chunks.info);
+        f.render_widget(info_view, layout_chunks.info);
+    }
 
     // Set the cursor depending on input mode
     if state.input_mode == InputMode::Insert {

--- a/simbelmyne/src/cli/play/tui.rs
+++ b/simbelmyne/src/cli/play/tui.rs
@@ -282,7 +282,6 @@ fn view(state: &mut State, f: &mut Frame) {
     let score = state.search.map_or(0, |search| search.score);
     let nodes_visited = state.search.map_or(0, |search| search.nodes_visited);
     let beta_cutoffs = state.search.map_or(0, |search| search.beta_cutoffs.iter().sum());
-    let tt_hits = state.search.map_or(0, |search| search.tt_hits);
     let duration = state.search.map_or(Duration::default(), |search| search.duration);
 
     let info_view = InfoView {
@@ -292,7 +291,6 @@ fn view(state: &mut State, f: &mut Frame) {
         beta_cutoffs,
         score,
         best_move,
-        tt_hits,
         tt_occupancy: state.tt_occupancy,
         tt_inserts: state.tt_inserts,
         tt_overwrites: state.tt_overwrites,

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -43,9 +43,6 @@ pub struct Search {
     /// The total number of nodes visited in this search
     pub nodes_visited: usize,
 
-    /// The total number of TT hits for the search
-    pub tt_hits: usize,
-
     /// The time the search took at any given ply
     pub duration: Duration,
 
@@ -70,7 +67,6 @@ impl Search {
             killers: [Killers::new(); MAX_DEPTH],
             history_table: HistoryTable::new(),
             nodes_visited: 0,
-            tt_hits: 0,
             duration: Duration::default(),
             beta_cutoffs: [0; MAX_DEPTH],
             opts,

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -46,9 +46,6 @@ pub struct Search {
     /// The time the search took at any given ply
     pub duration: Duration,
 
-    /// The number of beta-cutoffs we found at any given ply;
-    pub beta_cutoffs: [usize; MAX_DEPTH],
-
     // Controls
     /// Options that control what kinds of optimizations should be enabled.
     /// Mostly for debugging purposes
@@ -68,7 +65,6 @@ impl Search {
             history_table: HistoryTable::new(),
             nodes_visited: 0,
             duration: Duration::default(),
-            beta_cutoffs: [0; MAX_DEPTH],
             opts,
             aborted: false,
         }

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -74,7 +74,7 @@ pub struct SearchReport {
     pub duration: Duration,
     pub score: Eval,
     pub pv: Vec<Move>,
-    pub hashfull: f32,
+    pub hashfull: u32,
 }
 
 impl SearchReport {
@@ -86,7 +86,7 @@ impl SearchReport {
             nodes: search.tc.nodes(),
             duration: search.tc.elapsed(),
             pv: pv.into(),
-            hashfull: tt.occupancy(),
+            hashfull: (1000.0 * tt.occupancy()) as u32,
         }
     }
 
@@ -98,7 +98,7 @@ impl SearchReport {
             duration: Duration::ZERO,
             score: 0,
             pv: Vec::new(),
-            hashfull: 0.0,
+            hashfull: 0,
         }
     }
 }
@@ -326,6 +326,7 @@ impl Position {
         if !search.should_continue() {
             return Score::MIN;
         }
+
         search.tc.add_node();
         search.seldepth = search.seldepth.max(ply);
 

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -21,7 +21,8 @@ const NULL_MOVE_REDUCTION: usize = 3;
 /// A Search struct holds both the parameters, as well as metrics and results, for a given search.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Search {
-    // Information
+    // The (nominal) depth of this search. This does not take QSearch into 
+    // consideration
     pub depth: usize,
 
     // The principal variation so far
@@ -41,9 +42,6 @@ pub struct Search {
     // Stats
     /// The total number of nodes visited in this search
     pub nodes_visited: usize,
-
-    /// The total number of leaf nodes visited in this search
-    pub leaf_nodes: usize,
 
     /// The total number of TT hits for the search
     pub tt_hits: usize,
@@ -72,7 +70,6 @@ impl Search {
             killers: [Killers::new(); MAX_DEPTH],
             history_table: HistoryTable::new(),
             nodes_visited: 0,
-            leaf_nodes: 0,
             tt_hits: 0,
             duration: Duration::default(),
             beta_cutoffs: [0; MAX_DEPTH],

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -36,6 +36,9 @@ pub struct Search {
     // consideration
     pub depth: usize,
 
+    // The so-called "selective depth", the deepest ply we've searched
+    pub seldepth: usize,
+
     // The principal variation so far
     pub pv: PVTable,
 
@@ -63,6 +66,7 @@ impl Search {
     pub fn new(depth: usize) -> Self {
         Self {
             depth,
+            seldepth: 0,
             pv: PVTable::new(),
             score: 0,
             killers: [Killers::new(); MAX_DEPTH],
@@ -83,7 +87,7 @@ impl Search {
 
         SearchReport {
             depth: Some(self.depth as u8),
-            seldepth: Some(self.depth as u8),
+            seldepth: Some(self.seldepth as u8),
             score: Some(self.score),
             time: Some(self.duration.as_millis() as u64),
             nps,
@@ -313,6 +317,8 @@ impl Position {
         tc: &TimeControl,
     ) -> Eval {
         search.nodes_visited += 1;
+        search.seldepth = search.seldepth.max(ply);
+
         let mut local_pv = PVTable::new();
 
         if self.board.is_rule_draw() || self.is_repetition() {

--- a/simbelmyne/src/tests/mod.rs
+++ b/simbelmyne/src/tests/mod.rs
@@ -1,7 +1,3 @@
-use colored::Colorize;
-
-use crate::{search::SearchOpts, position::Position, transpositions::TTable, time_control::TimeControl};
-
 #[allow(dead_code)]
 pub const TEST_POSITIONS: [&str; 161] = [
     // Carp tests
@@ -171,56 +167,3 @@ pub const TEST_POSITIONS: [&str; 161] = [
     "4r1k1/1bq2r1p/p2p1np1/3Pppb1/P1P5/1N3P2/1R2B1PP/1Q1R2BK w - - 0 0",
     "8/8/8/8/4kp2/1R6/P2q1PPK/8 w - - 0 0",
 ];
-
-#[allow(dead_code)]
-pub fn run_test_suite(opts1: SearchOpts, opts2: SearchOpts, depth: usize) {
-    let mut results: Vec<(&str, bool)> = Vec::new();
-
-    for fen in TEST_POSITIONS {
-        let board = fen.parse().unwrap();
-        let position = Position::new(board);
-
-        let mut tt = TTable::with_capacity(64);
-        let (tc, _) = TimeControl::fixed_depth(depth);
-
-        let search1 = position.search(&mut tt, opts1, tc);
-        let best_move1 = search1.pv.pv_move();
-        let score1 = search1.score;
-
-        let mut tt = TTable::with_capacity(64);
-        let (tc, _) = TimeControl::fixed_depth(depth);
-
-        let search2 = position.search(&mut tt, opts2, tc);
-        let best_move2 = search2.pv.pv_move();
-        let score2 = search2.score;
-
-        // We'd expect to get back the same move, _or_, if not, the moves should
-        // have the same score
-        let passed = best_move1 == best_move2 || score1 == score2;
-
-        results.push((fen, passed));
-    }
-
-
-    // Print out the individual results
-    for (fen, passed) in results.iter() {
-        if *passed {
-            println!("{}", fen.green());
-        } else {
-            println!("{}", fen.red());
-        }
-    }
-
-    // Print out summary
-    let all = TEST_POSITIONS.len();
-    let num_passed = results.iter().filter(|(_, passed)| *passed).count();
-    let num_failed = all - num_passed;
-    println!("{} passed, {} failed", num_passed.to_string().green(), num_failed.to_string().red());
-
-    assert_eq!(
-        num_passed, 
-        all, 
-        "{} results differed in their resulting best moves", 
-        num_failed.to_string().red()
-    );
-}

--- a/simbelmyne/src/time_control.rs
+++ b/simbelmyne/src/time_control.rs
@@ -12,6 +12,7 @@ pub struct TimeControl {
     start: Instant,
     max_time: Duration,
     stop: Arc<AtomicBool>,
+    nodes: u32,
 }
 
 impl TimeControl {
@@ -44,6 +45,7 @@ impl TimeControl {
             max_time,
             start: Instant::now(),
             stop: stop.clone(),
+            nodes: 0,
         };
 
         let handle = TimeControlHandle { 
@@ -57,7 +59,7 @@ impl TimeControl {
         Self::new(TCType::Depth(depth), Color::White)
     }
 
-    pub fn should_continue(&self, depth: usize, nodes: usize) -> bool {
+    pub fn should_continue(&self, depth: usize) -> bool {
         // Always respect the global stop flag
         if self.stopped() {
             return false;
@@ -66,7 +68,7 @@ impl TimeControl {
         // If no global stop is detected, then respect the chosen time control
         match self.tc {
             TCType::Depth(max_depth) => depth < max_depth,
-            TCType::Nodes(max_nodes) => nodes < max_nodes,
+            TCType::Nodes(max_nodes) => self.nodes < max_nodes as u32,
             TCType::FixedTime(_) | TCType::VariableTime { .. } =>
                 self.start.elapsed() < self.max_time,
             _ => true,
@@ -79,6 +81,14 @@ impl TimeControl {
 
     pub fn elapsed(&self) -> Duration {
         self.start.elapsed()
+    }
+
+    pub fn add_node(&mut self) {
+        self.nodes += 1;
+    }
+
+    pub fn nodes(&self) -> u32 {
+        self.nodes
     }
 }
 

--- a/simbelmyne/src/transpositions.rs
+++ b/simbelmyne/src/transpositions.rs
@@ -148,8 +148,8 @@ impl TTable {
     }
 
     /// Return the occupancy as a rounded percentage (0 - 100)
-    pub fn occupancy(&self) -> usize {
-        100 * self.occupancy / self.table.len()
+    pub fn occupancy(&self) -> f32 {
+        1000.0 * self.occupancy as f32/ self.table.len() as f32
     }
 
     pub fn inserts(&self) -> usize {

--- a/simbelmyne/src/transpositions.rs
+++ b/simbelmyne/src/transpositions.rs
@@ -160,22 +160,3 @@ impl TTable {
         self.overwrites
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use crate::tests::run_test_suite;
-    use crate::search::SearchOpts;
-
-    #[test]
-    #[ignore] // Don't want these running on every single test run
-    /// Running with or without TT should not affect the outcome of the best move
-    fn transposition_table() {
-        const DEPTH: usize = 5;
-        let without_tt = SearchOpts::NONE;
-
-        let mut with_tt = SearchOpts::NONE;
-        with_tt.tt = true;
-
-        run_test_suite(without_tt, with_tt, DEPTH);
-    }
-}

--- a/simbelmyne/src/transpositions.rs
+++ b/simbelmyne/src/transpositions.rs
@@ -61,6 +61,10 @@ impl TTEntry {
         self.node_type
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.hash == ZHash::NULL
+    }
+
     pub fn try_use(&self, depth: usize, alpha: Eval, beta: Eval) -> Option<(Move, Eval)> {
         let entry_type = self.get_type();
         let entry_score = self.get_score();
@@ -122,14 +126,14 @@ impl TTable {
 
     pub fn insert(&mut self, entry: TTEntry) {
         let key: ZKey<{Self::COUNT}> = entry.hash.into();
-        let old_entry = self.table[key.0];
+        let slot = self.table[key.0];
 
-        if old_entry.hash == ZHash::default() {
+        if slot.is_empty() {
             // Empty slot, count as a new occupation
             self.table[key.0] = entry;
             self.inserts +=1;
             self.occupancy += 1;
-        } else if entry.depth > old_entry.depth {
+        } else if entry.depth > slot.depth {
             // Evicting existing record, doesn't change occupancy count
             self.inserts +=1;
             self.overwrites += 1;
@@ -147,9 +151,9 @@ impl TTable {
             .copied()
     }
 
-    /// Return the occupancy as a rounded percentage (0 - 100)
+    /// Return the occupancy as a fractional number (0 - 1)
     pub fn occupancy(&self) -> f32 {
-        1000.0 * self.occupancy as f32/ self.table.len() as f32
+        self.occupancy as f32 / self.table.len() as f32
     }
 
     pub fn inserts(&self) -> usize {

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -2,7 +2,6 @@ use std::io::BufRead;
 use std::io::stdout;
 use std::io::Write; 
 use chess::board::Board;
-use crate::search::SearchOpts;
 use crate::time_control::TimeControl;
 use crate::time_control::TimeControlHandle;
 use crate::transpositions::TTable;
@@ -104,9 +103,7 @@ impl SearchThread {
                     self.tc_handle = Some(tc_handle);
 
                     let mut tt = TTable::with_capacity(64);
-                    let opts = SearchOpts::ALL;
-                    // opts.killers = false;
-                    let search = self.position.search(&mut tt, opts, tc);
+                    let search = self.position.search(&mut tt, tc);
                     let mv = search.pv.pv_move();
                     println!("bestmove {mv}");
                 },

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -104,7 +104,7 @@ impl SearchThread {
 
                     let mut tt = TTable::with_capacity(64);
                     let search = self.position.search(&mut tt, tc);
-                    let mv = search.pv.pv_move();
+                    let mv = search.pv[0];
                     println!("bestmove {mv}");
                 },
 


### PR DESCRIPTION
Cleaning up the `Search` struct, which had become a bit of a grab-bag of mutable tables, statistics gathering, and duplicated variables, half of which were unused.

Ideally, I'd have liked to have the transposition table in the Search struct as well, but that gets awkward real quick. (Wait, does it?)