### PR TITLE
Chess/move

### DIFF
--- a/chess/src/movegen/attack_boards.rs
+++ b/chess/src/movegen/attack_boards.rs
@@ -1,4 +1,4 @@
-use crate::bitboard::Bitboard;
+use crate::{bitboard::Bitboard, piece::Color};
 
 type BBTable = [Bitboard; 64];
 type BBBTable = [[Bitboard; 64]; 64];
@@ -602,18 +602,26 @@ const BLACK: bool = false;
 const DOUBLE_PUSH: bool = true;
 const SINGLE_PUSH: bool = false;
 
-pub const W_PAWN_PUSHES: BBTable = gen_pawn_pushes::<WHITE, SINGLE_PUSH>();
-pub const B_PAWN_PUSHES: BBTable = gen_pawn_pushes::<BLACK, SINGLE_PUSH>();
-pub const W_PAWN_DPUSHES: BBTable = gen_pawn_pushes::<WHITE, DOUBLE_PUSH>();
-pub const B_PAWN_DPUSHES: BBTable = gen_pawn_pushes::<BLACK, DOUBLE_PUSH>();
-pub const W_PAWN_ATTACKS: BBTable = gen_pawn_attacks::<WHITE>();
-pub const B_PAWN_ATTACKS: BBTable = gen_pawn_attacks::<BLACK>();
-pub const KNIGHT_ATTACKS: BBTable = gen_knight_attacks();
-pub const KING_ATTACKS: BBTable = gen_king_attacks();
+pub const PAWN_PUSHES: [BBTable; Color::COUNT] = [
+    gen_pawn_pushes::<WHITE, SINGLE_PUSH>(),
+    gen_pawn_pushes::<BLACK, SINGLE_PUSH>(),
+];
 
+pub const PAWN_DBLPUSHES: [BBTable; Color::COUNT] = [
+    gen_pawn_pushes::<WHITE, DOUBLE_PUSH>(),
+    gen_pawn_pushes::<BLACK, DOUBLE_PUSH>(),
+];
+
+pub const PAWN_ATTACKS: [BBTable; Color::COUNT] = [
+    gen_pawn_attacks::<WHITE>(),
+    gen_pawn_attacks::<BLACK>(),
+];
+
+pub const KNIGHT_ATTACKS: BBTable = gen_knight_attacks();
 pub const BISHOP_ATTACKS: BBTable = gen_bishop_attacks();
 pub const ROOK_ATTACKS: BBTable = gen_rook_attacks();
 pub const QUEEN_ATTACKS: BBTable = gen_queen_attacks();
+pub const KING_ATTACKS: BBTable = gen_king_attacks();
 
 #[cfg(test)]
 mod tests {
@@ -704,29 +712,33 @@ mod tests {
 
     #[test]
     fn test_pawn_pushes() {
-        assert_eq!(W_PAWN_PUSHES[E5 as usize], Bitboard(0x100000000000));
-        assert_eq!(W_PAWN_PUSHES[E8 as usize], Bitboard(0x000000000000));
-        assert_eq!(B_PAWN_PUSHES[E5 as usize], Bitboard(0x10000000));
-        assert_eq!(B_PAWN_PUSHES[E1 as usize], Bitboard(0x000000000000));
+        use Color::*;
+
+        assert_eq!(PAWN_PUSHES[White as usize][E5 as usize], Bitboard(0x100000000000));
+        assert_eq!(PAWN_PUSHES[White as usize][E8 as usize], Bitboard(0x000000000000));
+        assert_eq!(PAWN_PUSHES[Black as usize][E5 as usize], Bitboard(0x10000000));
+        assert_eq!(PAWN_PUSHES[Black as usize][E1 as usize], Bitboard(0x000000000000));
 
         // Double pushes
-        assert_eq!(W_PAWN_DPUSHES[E5 as usize], Bitboard(0x10100000000000));
-        assert_eq!(W_PAWN_DPUSHES[E7 as usize], Bitboard(0x1000000000000000));
-        assert_eq!(B_PAWN_DPUSHES[E5 as usize], Bitboard(0x10100000));
-        assert_eq!(B_PAWN_DPUSHES[E2 as usize], Bitboard(0x10));
+        assert_eq!(PAWN_DBLPUSHES[White as usize][E5 as usize], Bitboard(0x10100000000000));
+        assert_eq!(PAWN_DBLPUSHES[White as usize][E7 as usize], Bitboard(0x1000000000000000));
+        assert_eq!(PAWN_DBLPUSHES[Black as usize][E5 as usize], Bitboard(0x10100000));
+        assert_eq!(PAWN_DBLPUSHES[Black as usize][E2 as usize], Bitboard(0x10));
     }
 
     #[test]
     fn test_pawn_attacks() {
-        assert_eq!(W_PAWN_ATTACKS[E5 as usize], Bitboard(0x280000000000));
-        assert_eq!(W_PAWN_ATTACKS[A5 as usize], Bitboard(0x20000000000));
-        assert_eq!(W_PAWN_ATTACKS[H5 as usize], Bitboard(0x400000000000));
-        assert_eq!(W_PAWN_ATTACKS[E8 as usize], Bitboard(0x00));
+        use Color::*;
 
-        assert_eq!(B_PAWN_ATTACKS[E5 as usize], Bitboard(0x28000000));
-        assert_eq!(B_PAWN_ATTACKS[A5 as usize], Bitboard(0x2000000));
-        assert_eq!(B_PAWN_ATTACKS[H5 as usize], Bitboard(0x40000000));
-        assert_eq!(B_PAWN_ATTACKS[E1 as usize], Bitboard(0x00));
+        assert_eq!(PAWN_ATTACKS[White as usize][E5 as usize], Bitboard(0x280000000000));
+        assert_eq!(PAWN_ATTACKS[White as usize][A5 as usize], Bitboard(0x20000000000));
+        assert_eq!(PAWN_ATTACKS[White as usize][H5 as usize], Bitboard(0x400000000000));
+        assert_eq!(PAWN_ATTACKS[White as usize][E8 as usize], Bitboard(0x00));
+
+        assert_eq!(PAWN_ATTACKS[Black as usize][E5 as usize], Bitboard(0x28000000));
+        assert_eq!(PAWN_ATTACKS[Black as usize][A5 as usize], Bitboard(0x2000000));
+        assert_eq!(PAWN_ATTACKS[Black as usize][H5 as usize], Bitboard(0x40000000));
+        assert_eq!(PAWN_ATTACKS[Black as usize][E1 as usize], Bitboard(0x00));
     }
 
     #[test]

--- a/chess/src/movegen/moves.rs
+++ b/chess/src/movegen/moves.rs
@@ -128,6 +128,10 @@ impl Move {
     }
 }
 
+/// A simpler type of Move that doesn't contain as much metadata
+///
+/// This is mostly used for converting between algebraic notation and _actual_
+/// moves, where algebraic data doesn't capture any metadata except promotions,
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct BareMove {
     src: Square,
@@ -144,19 +148,21 @@ impl BareMove {
         }
     }
 
+    /// Get the source square for this move.
     pub fn src(&self) -> Square {
         self.src
     }
 
+    /// Get the target square for this move.
     pub fn tgt(&self) -> Square {
         self.tgt
     }
-    
+
+    /// Get the promotion square for this move, if any
     pub fn promo_type(&self) -> Option<Piece> {
         self.promo_type
     }
 }
-
 
 /// Nibble-sized encoding of some metadata associated with a Move
 #[rustfmt::skip]

--- a/chess/src/movegen/moves.rs
+++ b/chess/src/movegen/moves.rs
@@ -1,92 +1,27 @@
 use crate::piece::PieceType;
 use crate::piece::Piece;
 use crate::piece::Color;
-use crate::movegen::attack_boards::*;
-use crate::bitboard::Bitboard;
 use crate::square::Square;
-use crate::movegen::attack_boards::Direction;
 use itertools::Itertools;
 use anyhow::anyhow;
 use std::{fmt::Display, str::FromStr};
+use MoveType::*;
 
-use super::attack_boards::Rank;
-
-#[rustfmt::skip]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[repr(u16)]
-pub enum MoveType {
-    Quiet                 = 0b0000,
-    DoublePush            = 0b0001,
-    KingCastle            = 0b0010,
-    QueenCastle           = 0b0011,
-    Capture               = 0b0100,
-    EnPassant             = 0b0101,
-    KnightPromo           = 0b1000,
-    BishopPromo           = 0b1001,
-    RookPromo             = 0b1010,
-    QueenPromo            = 0b1011,
-    KnightPromoCapture    = 0b1100,
-    BishopPromoCapture    = 0b1101,
-    RookPromoCapture      = 0b1110,
-    QueenPromoCapture     = 0b1111,
-}
-
-impl MoveType {
-    const ALL: [MoveType; 16] = [
-        MoveType::Quiet,
-        MoveType::DoublePush,
-        MoveType::KingCastle,
-        MoveType::QueenCastle,
-        MoveType::Capture,
-        MoveType::EnPassant,
-        MoveType::Quiet,
-        MoveType::Quiet,
-        MoveType::KnightPromo,
-        MoveType::BishopPromo,
-        MoveType::RookPromo,
-        MoveType::QueenPromo,
-        MoveType::KnightPromoCapture,
-        MoveType::BishopPromoCapture,
-        MoveType::RookPromoCapture,
-        MoveType::QueenPromoCapture,
-    ];
-}
-
-impl FromStr for MoveType {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> anyhow::Result<Self> {
-        use MoveType::*;
-
-        match s {
-            "N" | "n" => Ok(KnightPromo),
-            "B" | "b" => Ok(BishopPromo),
-            "R" | "r" => Ok(RookPromo),
-            "Q" | "q" => Ok(QueenPromo),
-            _ => Err(anyhow!("Not a valid promotion label"))
-        }
-        
-    }
-}
-
-/// Pack all the metadata related to a Move in a u16
+/// Packs all the metadata related to a Move in a u16
 ///
 /// 6 bits (0 - 63) for the source square
 /// 6 bits (0 - 63) for the target square
 /// 4 bits (0 - 16) for additional metadata (castling, captures, promotions)
-/// When we get to move sorting, to we also want to squeeze in the sorting rank
-/// here?
-/// cf. Rustic https://github.com/mvanthoor/rustic/blob/17b15a34b68000dffb681277c3ef6fc98f935a0b/src/movegen/defs.rs
-/// cf. Carp https://github.com/dede1751/carp/blob/main/chess/src/moves.rs
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Move(u16);
 
 impl Move {
+    pub const NULL: Move = Move(0);
     const SRC_MASK: u16  = 0b0000_0000_0011_1111;
     const TGT_MASK: u16  = 0b0000_1111_1100_0000;
     const TYPE_MASK: u16 = 0b1111_0000_0000_0000;
-    pub const NULL: Move = Move(0);
 
+    /// Create a new Move from source, target, and movetype
     pub fn new(src: Square, tgt: Square, mtype: MoveType) -> Move {
         let mut value = 0u16;
         value |= src as u16;
@@ -96,55 +31,55 @@ impl Move {
         Move(value)
     }
 
+    ///  Get the source square for a move
     pub fn src(self) -> Square {
         ((self.0 & Self::SRC_MASK) as usize).into()
     }
 
+    /// Get the target square for a move
     pub fn tgt(self) -> Square {
         (((self.0 & Self::TGT_MASK) >> 6) as usize).into()
     }
 
+    /// Get the move type for a move.
     pub fn get_type(self) -> MoveType {
         let idx = (self.0 & Self::TYPE_MASK) >> 12;
         MoveType::ALL[idx as usize]
     }
 
+    /// Check whether the move is quiet (no capture, promotion, castle, etc...)
     pub fn is_quiet(self) -> bool {
         self.get_type() == MoveType::Quiet
     }
 
+    /// Check whether the move is a castling move
     pub fn is_castle(self) -> bool {
         self.get_type() == MoveType::KingCastle 
         || self.get_type() == MoveType::QueenCastle
     }
 
+    /// Check whether the move is a double push
     pub fn is_double_push(self) -> bool {
         self.get_type() == MoveType::DoublePush
     }
 
+    /// Check whether the move is an en-passant capture
     pub fn is_en_passant(self) -> bool {
         self.get_type() == MoveType::EnPassant
     }
 
+    /// Check whether the move is a promotion
     pub fn is_promotion(self) -> bool {
         self.0 & (1 << 15) != 0
     }
 
+    /// Check whether the move is a capture
     pub fn is_capture(self) -> bool {
         self.0 & (1 << 14) != 0
     }
 
-
-    pub fn get_ep_square(self) -> Option<Square> {
-        if self.is_double_push() {
-            Some(BETWEEN[self.src() as usize][self.tgt() as usize].first())
-        } else {
-            None
-        }
-    }
-
+    /// Get the promotion type from a move
     pub fn get_promo_type(self) -> Option<PieceType> {
-        use MoveType::*;
         use PieceType::*;
 
         match self.get_type() {
@@ -163,11 +98,9 @@ impl Move {
     // (i.e., if it's a pawn move), or that the MoveType is correctly set to
     // a promotion MoveType.
     pub fn get_promo_color(self) -> Option<Color> {
-        let target: Bitboard = self.tgt().into();
-
-        if (target & Rank::W_PROMO_RANK) != Bitboard::EMPTY {
+        if self.tgt().rank() == 7 {
             Some(Color::White)
-        } else if (target & Rank::B_PROMO_RANK) != Bitboard::EMPTY {
+        } else if self.tgt().rank() == 0 {
             Some(Color::Black)
         } else {
             None
@@ -195,6 +128,83 @@ impl Move {
     }
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct BareMove {
+    src: Square,
+    tgt: Square,
+    promo_type: Option<Piece>,
+}
+
+impl BareMove {
+    pub fn new(src: Square, tgt: Square, promo_type: Option<Piece>) -> Self {
+        Self {
+            src,
+            tgt,
+            promo_type,
+        }
+    }
+
+    pub fn src(&self) -> Square {
+        self.src
+    }
+
+    pub fn tgt(&self) -> Square {
+        self.tgt
+    }
+    
+    pub fn promo_type(&self) -> Option<Piece> {
+        self.promo_type
+    }
+}
+
+
+/// Nibble-sized encoding of some metadata associated with a Move
+#[rustfmt::skip]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u16)]
+pub enum MoveType {
+    Quiet                 = 0b0000,
+    DoublePush            = 0b0001,
+    KingCastle            = 0b0010,
+    QueenCastle           = 0b0011,
+    Capture               = 0b0100,
+    EnPassant             = 0b0101,
+    KnightPromo           = 0b1000,
+    BishopPromo           = 0b1001,
+    RookPromo             = 0b1010,
+    QueenPromo            = 0b1011,
+    KnightPromoCapture    = 0b1100,
+    BishopPromoCapture    = 0b1101,
+    RookPromoCapture      = 0b1110,
+    QueenPromoCapture     = 0b1111,
+}
+
+impl MoveType {
+    const ALL: [MoveType; 16] = [
+        Quiet,
+        DoublePush,
+        KingCastle,
+        QueenCastle,
+        Capture,
+        EnPassant,
+        Quiet,
+        Quiet,
+        KnightPromo,
+        BishopPromo,
+        RookPromo,
+        QueenPromo,
+        KnightPromoCapture,
+        BishopPromoCapture,
+        RookPromoCapture,
+        QueenPromoCapture,
+    ];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Utility traits
+//
+////////////////////////////////////////////////////////////////////////////////
 
 impl Display for Move {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -239,169 +249,26 @@ impl FromStr for Move {
     }
 }
 
+impl FromStr for MoveType {
+    type Err = anyhow::Error;
 
-impl Piece {
-    /// All the squares that are _visible_ to the piece.
-    /// This means all unoccupied squares in the pieces main directions, up
-    /// until (and including), the first blocker piece.
-    ///
-    /// This blocker can be either friendly or enemy, so we need to mask out
-    /// friendly pieces if we're interested in attacks
-    pub fn visible_squares(&self, sq: Square, ours: Bitboard, theirs: Bitboard) -> Bitboard {
-        use PieceType::*;
-        let blockers = ours | theirs;
-
-        match self.piece_type() {
-            Bishop => {
-                let mut visible = Bitboard::EMPTY;
-                for dir in Direction::DIAG {
-                    visible |= sq.visible_ray(dir, blockers);
-                }
-                visible
-            }
-
-            Rook => {
-                let mut visible = Bitboard::EMPTY;
-                for dir in Direction::HV {
-                    visible |= sq.visible_ray(dir, blockers);
-                }
-                visible
-            }
-
-            Queen => {
-                let mut visible = Bitboard::EMPTY;
-                for dir in Direction::ALL {
-                    visible |= sq.visible_ray(dir, blockers);
-                }
-                visible
-            }
-
-            Knight => KNIGHT_ATTACKS[sq as usize],
-
-            King => KING_ATTACKS[sq as usize],
-
-            Pawn => {
-                let mut visible = Bitboard::EMPTY;
-
-                if self.color().is_white() {
-                    let on_original_rank = sq.rank() == 1;
-                    let single_push = W_PAWN_PUSHES[sq as usize] & !blockers;
-
-                    visible |= theirs & W_PAWN_ATTACKS[sq as usize];
-                    visible |= single_push;
-
-                    if on_original_rank && single_push != Bitboard::EMPTY {
-                        visible |= W_PAWN_DPUSHES[sq as usize] & !blockers;
-                    } 
-                } else {
-                    let on_original_rank = sq.rank() == 6;
-                    let single_push = B_PAWN_PUSHES[sq as usize] & !blockers;
-
-                    visible |= theirs & B_PAWN_ATTACKS[sq as usize];
-                    visible |= single_push;
-
-                    if on_original_rank && single_push != Bitboard::EMPTY {
-                        visible |= B_PAWN_DPUSHES[sq as usize] & !blockers;
-                    }
-                }
-
-                visible
-            }
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        match s {
+            "N" | "n" => Ok(KnightPromo),
+            "B" | "b" => Ok(BishopPromo),
+            "R" | "r" => Ok(RookPromo),
+            "Q" | "q" => Ok(QueenPromo),
+            _ => Err(anyhow!("Not a valid promotion label"))
         }
+        
     }
 }
 
-pub fn visible_squares(
-    square: Square,
-    piece_type: PieceType,
-    color: Color,
-    ours: Bitboard,
-    theirs: Bitboard,
-) -> Bitboard {
-    use PieceType::*;
-    let blockers = ours | theirs;
-
-    match piece_type {
-        Bishop => {
-            let mut visible = Bitboard::EMPTY;
-            for dir in Direction::DIAG {
-                visible |= square.visible_ray(dir, blockers);
-            }
-            visible
-        }
-
-        Rook => {
-            let mut visible = Bitboard::EMPTY;
-            for dir in Direction::HV {
-                visible |= square.visible_ray(dir, blockers);
-            }
-            visible
-        }
-
-        Queen => {
-            let mut visible = Bitboard::EMPTY;
-            for dir in Direction::ALL {
-                visible |= square.visible_ray(dir, blockers);
-            }
-            visible
-        }
-
-        Knight => KNIGHT_ATTACKS[square as usize],
-
-        King => KING_ATTACKS[square as usize],
-
-        Pawn => {
-            let mut visible = Bitboard::EMPTY;
-
-            if color.is_white() {
-                visible |= theirs & W_PAWN_ATTACKS[square as usize];
-
-                if square.rank() == 1 {
-                    visible |= W_PAWN_DPUSHES[square as usize] & !theirs;
-                } else {
-                    visible |= W_PAWN_PUSHES[square as usize] & !theirs;
-                }
-            } else {
-                visible |= theirs & B_PAWN_ATTACKS[square as usize];
-
-                if square.rank() == 6 {
-                    visible |= B_PAWN_DPUSHES[square as usize] & !theirs;
-                } else {
-                    visible |= B_PAWN_PUSHES[square as usize] & !theirs;
-                }
-            }
-
-            visible
-        }
-    }
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct BareMove {
-    src: Square,
-    tgt: Square,
-    promo_type: Option<Piece>,
-}
-
-impl BareMove {
-    pub fn new(src: Square, tgt: Square, promo_type: Option<Piece>) -> Self {
-        Self {
-            src,
-            tgt,
-            promo_type,
-        }
-    }
-
-    pub fn src(&self) -> Square {
-        self.src
-    }
-
-    pub fn tgt(&self) -> Square {
-        self.tgt
-    }
-    
-    pub fn promo_type(&self) -> Option<Piece> {
-        self.promo_type
+impl PartialEq<BareMove> for Move {
+    fn eq(&self, bare: &BareMove) -> bool {
+        self.src() == bare.src()
+            && self.tgt() == bare.tgt()
+            && bare.promo_type().map(|piece| piece.piece_type()) == self.get_promo_type()
     }
 }
 
@@ -460,13 +327,11 @@ impl Display for BareMove {
     }
 }
 
-impl PartialEq<BareMove> for Move {
-    fn eq(&self, bare: &BareMove) -> bool {
-        self.src() == bare.src()
-            && self.tgt() == bare.tgt()
-            && bare.promo_type().map(|piece| piece.piece_type()) == self.get_promo_type()
-    }
-}
+////////////////////////////////////////////////////////////////////////////////
+//
+// Tests
+//
+////////////////////////////////////////////////////////////////////////////////
 
 #[cfg(test)]
 mod tests {

--- a/chess/src/piece.rs
+++ b/chess/src/piece.rs
@@ -13,7 +13,6 @@ pub enum Piece {
     WP, BP, WN, BN, WB, BB, WR, BR, WQ, BQ, WK, BK
 }
 
-#[allow(dead_code)]
 impl Piece {
     pub const COUNT: usize = 12;
 

--- a/chess/src/square.rs
+++ b/chess/src/square.rs
@@ -109,7 +109,6 @@ impl Square {
     pub fn flip(&self) -> Self {
         ((*self as usize) ^ 56).into()
     }
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -176,40 +175,26 @@ impl Square {
 
     /// Get a bitboard for all the squares visible to a bishop on this square.
     pub fn bishop_squares(self, blockers: Bitboard) -> Bitboard {
-        let mut visible = Bitboard::EMPTY;
-
-        for dir in Direction::DIAG {
-            visible |= self.visible_ray(dir, blockers);
-        }
-
-        visible
+        Direction::DIAG.into_iter()
+            .fold(Bitboard::EMPTY, |acc, dir| acc | self.visible_ray(dir, blockers))
     }
 
     /// Get a bitboard for all the squares visible to a rook on this square.
     pub fn rook_squares(self, blockers: Bitboard) -> Bitboard {
-        let mut visible = Bitboard::EMPTY;
-
-        for dir in Direction::HV {
-            visible |= self.visible_ray(dir, blockers);
-        }
-
-        visible
+        Direction::HV.into_iter()
+            .fold(Bitboard::EMPTY, |acc, dir| acc | self.visible_ray(dir, blockers))
     }
 
+    /// Get a bitboard for all the squares visible to a queen on this square.
     pub fn queen_squares(self, blockers: Bitboard) -> Bitboard {
-        let mut visible = Bitboard::EMPTY;
-
-        for dir in Direction::ALL {
-            visible |= self.visible_ray(dir, blockers);
-        }
-
-        visible
+        Direction::ALL.into_iter()
+            .fold(Bitboard::EMPTY, |acc, dir| acc | self.visible_ray(dir, blockers))
     }
 
+    /// Get a bitboard for all the squares visible to a king on this square.
     pub fn king_squares(self) -> Bitboard {
         KING_ATTACKS[self as usize]
     }
-
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
More cleanup!

Not entirely sure why, but for some reason Past Me figured it'd be a good idea to have an implementation of `Piece::visible_squares` in `moves.rs`.

Moved that around to live in a separate `Square` impl block dedicated to piece movement and tightened everything up a bit more.