### PR TITLE
Draw issues

### DIFF
--- a/chess/src/board.rs
+++ b/chess/src/board.rs
@@ -297,17 +297,21 @@ impl Board {
 
     /// Check whether the board has insufficient material for either player to
     /// mate.
-    ///
-    // Since we're looking for efficiency here, we're better off identifying
-    // positions where mate can't be _forced_, even if theoretically possible. 
-    // The quicker we find a (likely) draw, the better (i.e., just like 
-    // checkmate, we should break off the search and return a draw asap.
     pub fn insufficient_material(&self) -> bool {
+        use PieceType::*;
+        use Color::*;
         let occupied = self.all_occupied();
-        let knights = self.piece_bbs[PieceType::Knight as usize];
-        let bishops = self.piece_bbs[PieceType::Bishop as usize];
-        let same_color_bishops = (bishops & LIGHT_SQUARES).count() > 0
-            || (bishops & DARK_SQUARES).count() > 0;
+        let pawns = self.piece_bbs[Pawn as usize];
+        let knights = self.piece_bbs[Knight as usize];
+        let bishops = self.piece_bbs[Bishop as usize];
+        let white_bishops = self.bishops(White);
+        let black_bishops = self.bishops(White);
+        let light_square_bishops = bishops & LIGHT_SQUARES;
+        let dark_square_bishops = bishops & DARK_SQUARES;
+
+        if pawns.count() > 0 {
+            return false;
+        }
 
         // Two kings is insufficient
         if occupied.count() == 2 {
@@ -320,7 +324,9 @@ impl Board {
         }
 
         // Same colored bishops is insufficient
-        if occupied.count() == 4 && same_color_bishops {
+        if occupied.count() == 4
+        && (white_bishops.count() == 1 && black_bishops.count() == 1)
+        && (light_square_bishops.count() == 2 || dark_square_bishops.count() == 2) {
             return true;
         }
 

--- a/journal/2023-12-19.norg
+++ b/journal/2023-12-19.norg
@@ -193,3 +193,19 @@
 
     Actually, I tried disabling QSearch again, and the issue is _definitely_ still 
     there, even if it's less pronounced.
+
+* Contempt seems to help
+  Fixing the insufficient_material bug and adding a hefty contempt seams to 
+  alleviate some of the issue
+
+   @code text
+   Score of Simbelmyne vs Simbelmyne 2: 199 - 182 - 119 [0.517]
+   ...      Simbelmyne playing White: 113 - 75 - 62  [0.576] 250
+   ...      Simbelmyne playing Black: 86 - 107 - 57  [0.458] 250
+   ...      White vs Black: 220 - 161 - 119  [0.559] 500
+   Elo difference: 11.8 +/- 26.6, LOS: 80.8 %, DrawRatio: 23.8 %
+   500 of 500 games finished.
+   @end
+
+  Still not quite there yet, but definitely an improvement. I wonder how that
+  does against Blunder. Does the contempt mean I'll play significantly worse?

--- a/simbelmyne/src/evaluate/mod.rs
+++ b/simbelmyne/src/evaluate/mod.rs
@@ -74,7 +74,7 @@ impl Score {
     pub const MIN: Eval = Eval::MIN + 1;
     pub const MAX: Eval = Eval::MAX;
     pub const MATE: Eval = 20_000;
-    pub const DRAW: Eval = 0;
+    pub const DRAW: Eval = 150;
 
     /// Create a new score for a board
     pub fn new(board: &Board) -> Self {

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -180,7 +180,7 @@ impl Position {
         // Don't return early when in the root node, because we won't have a PV 
         // move to play.
         if (self.board.is_rule_draw() || self.is_repetition()) && !in_root {
-            return Score::DRAW;
+            return if ply % 2 == 1 { Score::DRAW } else { - Score::DRAW };
         }
 
         if ply >= MAX_DEPTH {
@@ -296,7 +296,7 @@ impl Position {
 
         // Stalemate?
         if legal_moves.len() == 0 && !in_check {
-            return Score::DRAW;
+            return if ply % 2 == 1 { Score::DRAW } else { - Score::DRAW };
         }
 
         for mv in &mut legal_moves {
@@ -407,7 +407,7 @@ impl Position {
         search.seldepth = search.seldepth.max(ply);
 
         if self.board.is_rule_draw() || self.is_repetition() {
-            return Score::DRAW
+            return if ply % 2 == 1 { Score::DRAW } else { - Score::DRAW };
         }
 
         let mut local_pv = PVTable::new();


### PR DESCRIPTION
Fix the "bishops on the same color square" condition in `insufficient_material`.
Also adds a hefty contempt factor to stop the engine from drawing all of the time.

Doesn't actually seem to have done much, Elo wise, but I _think_ we're seeing less draws and black/white asymmetry?

```
Score of Simbelmyne vs Simbelmyne v1.0.0: 188 - 197 - 115 [0.491]
...      Simbelmyne playing White: 126 - 76 - 48  [0.600] 250
...      Simbelmyne playing Black: 62 - 121 - 67  [0.382] 250
...      White vs Black: 247 - 138 - 115  [0.609] 500
Elo difference: -6.3 +/- 26.7, LOS: 32.3 %, DrawRatio: 23.0 %
500 of 500 games finished.
```