### PR TITLE
Add penalty for doubled pawns

### DIFF
--- a/journal/2023-12-23.norg
+++ b/journal/2023-12-23.norg
@@ -1,0 +1,25 @@
+* Isolated pawns
+
+** -30/-40
+
+  @code text
+  Score of Simbelmyne vs Simbelmyne main: 210 - 192 - 98 [0.518]
+  ...      Simbelmyne playing White: 143 - 55 - 52  [0.676] 250
+  ...      Simbelmyne playing Black: 67 - 137 - 46  [0.360] 250
+  ...      White vs Black: 280 - 122 - 98  [0.658] 500
+  Elo difference: 12.5 +/- 27.3, LOS: 81.5 %, DrawRatio: 19.6 %
+  500 of 500 games finished.
+  @end
+
+   It's a start...
+** -23/-34 (viridithas)
+  @code text
+  Score of Simbelmyne vs Simbelmyne main: 173 - 161 - 73 [0.515]
+  ...      Simbelmyne playing White: 105 - 58 - 41  [0.615] 204
+  ...      Simbelmyne playing Black: 68 - 103 - 32  [0.414] 203
+  ...      White vs Black: 208 - 126 - 73  [0.601] 407
+  Elo difference: 10.2 +/- 30.6, LOS: 74.4 %, DrawRatio: 17.9 %
+  413 of 500 games finished.
+  @end
+
+   No _real_ difference here, either...

--- a/simbelmyne/src/evaluate/lookups.rs
+++ b/simbelmyne/src/evaluate/lookups.rs
@@ -14,6 +14,8 @@ pub const PASSED_PAWN_MASKS: [BBTable; Color::COUNT] = gen_passed_pawn_masks();
 
 pub const ISOLATED_PAWN_MASKS: BBTable = gen_isolated_pawn_masks();
 
+pub const DOUBLED_PAWN_MASKS: [Bitboard; 8] = gen_doubled_pawn_masks();
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 // Passed pawn masks
@@ -94,7 +96,7 @@ pub const EG_PASSED_PAWN_TABLE: [Eval; Square::COUNT]  = [
 // Isolated pawn masks
 //
 ////////////////////////////////////////////////////////////////////////////////
-///
+
 const fn gen_isolated_pawn_masks() -> BBTable {
     const A_FILE: Bitboard = Bitboard(0x101010101010101);
 
@@ -122,6 +124,25 @@ const fn gen_isolated_pawn_masks() -> BBTable {
     masks
 }
 
+////////////////////////////////////////////////////////////////////////////////
+//
+// Doubled pawn masks
+//
+////////////////////////////////////////////////////////////////////////////////
+
+const fn gen_doubled_pawn_masks() -> [Bitboard; 8] {
+    const A_FILE: Bitboard = Bitboard(0x101010101010101);
+    let mut rank: usize = 0;
+    let mut masks = [Bitboard::EMPTY; 8];
+
+    while rank < 8 {
+        let mask = A_FILE.0 << rank;
+        masks[rank] = Bitboard(mask);
+        rank += 1;
+    }
+    
+    masks
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
```
Score of Simbelmyne vs Simbelmyne main: 210 - 192 - 98 [0.518]
...      Simbelmyne playing White: 143 - 55 - 52  [0.676] 250
...      Simbelmyne playing Black: 67 - 137 - 46  [0.360] 250
...      White vs Black: 280 - 122 - 98  [0.658] 500
Elo difference: 12.5 +/- 27.3, LOS: 81.5 %, DrawRatio: 19.6 %
500 of 500 games finished.
```

Slightly depressing, now that I know how impactful some of these pawn structure terms can be (#122). Still, gotta appreciate the little things, I suppose?