### PR TITLE
Simbelmyne/reverse futility pruning

### DIFF
--- a/simbelmyne/src/search/aspiration.rs
+++ b/simbelmyne/src/search/aspiration.rs
@@ -38,7 +38,7 @@ impl Position {
         }
 
         loop {
-            let score = self.negamax(
+            let score = self.negamax::<true>(
                 0,
                 depth,
                 alpha,

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -22,7 +22,7 @@ const QUIETS: bool = true;
 
 impl Position {
     /// The main negamax function of the search routine.
-    pub fn negamax(
+    pub fn negamax<const PV: bool>(
         &self, 
         ply: usize, 
         mut depth: usize,
@@ -131,6 +131,7 @@ impl Position {
             && try_null
             && !in_root
             && !in_check
+            && !PV
             && depth >= NULL_MOVE_REDUCTION + 1;
 
         if should_null_prune {
@@ -157,7 +158,7 @@ impl Position {
         // resulting positions
         //
         ////////////////////////////////////////////////////////////////////////
-        let mut legal_moves = MovePicker::new(
+        let legal_moves = MovePicker::new(
             &self,  
             self.board.legal_moves::<QUIETS>(),
             tt_entry.map(|entry| entry.get_move()),
@@ -175,14 +176,18 @@ impl Position {
             return if ply % 2 == 1 { Score::DRAW } else { - Score::DRAW };
         }
 
-        for mv in &mut legal_moves {
+        for (move_count, mv) in legal_moves.enumerate() {
             if !search.should_continue() {
                 return Score::MIN;
             }
 
-            let score = -self
+            let score;
+
+            // PV Move
+            if move_count == 0 {
+            score = -self
                 .play_move(mv)
-                .negamax(ply + 1, 
+                .negamax::<true>(ply + 1, 
                     depth - 1, 
                     -beta, 
                     -alpha, 
@@ -191,6 +196,21 @@ impl Position {
                     search, 
                     true
                 );
+
+            } else {
+            score = -self
+                .play_move(mv)
+                .negamax::<false>(ply + 1, 
+                    depth - 1, 
+                    -beta, 
+                    -alpha, 
+                    tt, 
+                    &mut local_pv, 
+                    search, 
+                    true
+                );
+            }
+
 
             if score > best_score {
                 best_score = score;

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -1,15 +1,11 @@
 use crate::evaluate::Eval;
 
-// Search parameters
-pub const MAX_DEPTH           : usize = 128;
-pub const NULL_MOVE_REDUCTION : usize = 3;
-
-// Aspiration search parameters
-pub const ASPIRATION_MIN_DEPTH: usize = 4;
-pub const ASPIRATION_BASE_WINDOW: Eval = 30;
-pub const ASPIRATION_MAX_WINDOW: Eval = 900;
-
+////////////////////////////////////////////////////////////////////////////////
+//
 // Search options
+//
+////////////////////////////////////////////////////////////////////////////////
+
 pub const USE_TT           : bool = true;
 pub const MOVE_ORDERING    : bool = true;
 pub const TT_MOVE          : bool = true;
@@ -20,3 +16,22 @@ pub const NULL_MOVE_PRUNING: bool = true;
 pub const QUIESCENCE_SEARCH: bool = true;
 pub const DEBUG            : bool = true;
 
+////////////////////////////////////////////////////////////////////////////////
+//
+// Search parameters
+//
+////////////////////////////////////////////////////////////////////////////////
+
+pub const MAX_DEPTH           : usize = 128;
+
+// Null-move pruning
+pub const NULL_MOVE_REDUCTION : usize = 3;
+
+// Aspiration search
+pub const ASPIRATION_MIN_DEPTH: usize = 4;
+pub const ASPIRATION_BASE_WINDOW: Eval = 30;
+pub const ASPIRATION_MAX_WINDOW: Eval = 900;
+
+// Reverse futility pruning
+pub const RFP_THRESHOLD: usize = 8;
+pub const RFP_MARGIN: Eval = 80;

--- a/simbelmyne/src/search/zero_window.rs
+++ b/simbelmyne/src/search/zero_window.rs
@@ -16,6 +16,6 @@ impl Position {
         search: &mut Search,
         try_null: bool,
     ) -> Eval {
-        self.negamax(ply, depth, value-1, value, tt, pv, search, try_null)
+        self.negamax::<false>(ply, depth, value-1, value, tt, pv, search, try_null)
     }
 }


### PR DESCRIPTION
```
Score of Simbelmyne vs Simbelmyne main: 541 - 321 - 138 [0.610]
...      Simbelmyne playing White: 331 - 108 - 61  [0.723] 500
...      Simbelmyne playing Black: 210 - 213 - 77  [0.497] 500
...      White vs Black: 544 - 318 - 138  [0.613] 1000
Elo difference: 77.7 +/- 20.4, LOS: 100.0 %, DrawRatio: 13.8 %
1000 of 1000 games finished.
```