### PR TITLE
Add late move reductions (92 +/- 18)

### DIFF
--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -56,3 +56,34 @@ pub const HIST_AGE_DIVISOR: i32 = 4;
 // Late move pruning
 pub const LMP_THRESHOLD: usize = 8;
 pub const LMP_MOVE_THRESHOLDS: [usize; 9] = [0, 5, 8, 13, 20, 29, 40, 53, 68];
+
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Late move reductions
+//
+////////////////////////////////////////////////////////////////////////////////
+
+pub const LMR_MIN_DEPTH: usize = 3;
+pub const LMR_THRESHOLD: usize = 3;
+
+pub const LMR_MAX_MOVES: usize = 256;
+pub const LMR_TABLE: [[usize; LMR_MAX_MOVES]; MAX_DEPTH + 1] = lmr_table();
+
+const fn lmr_table() -> [[usize; LMR_MAX_MOVES]; MAX_DEPTH + 1] {
+    let mut lmr_table = [[0; LMR_MAX_MOVES]; MAX_DEPTH + 1];
+    let mut depth = 0;
+    let mut move_count = 0;
+
+    while depth < MAX_DEPTH + 1 {
+        while move_count < LMR_MAX_MOVES {
+            lmr_table[depth][move_count] = 
+                move_count / 12 + if depth < 8 { 2 } else { depth / 4 };
+
+            move_count += 1;
+        }
+        depth += 1;
+    }
+
+    lmr_table
+}


### PR DESCRIPTION
Pretty wild to still be able to get an Elo boost this big, this late in the game...

```
Score of Simbelmyne vs Simbelmyne main: 478 - 220 - 302 [0.629]
...      Simbelmyne playing White: 283 - 76 - 141  [0.707] 500
...      Simbelmyne playing Black: 195 - 144 - 161  [0.551] 500
...      White vs Black: 427 - 271 - 302  [0.578] 1000
Elo difference: 91.7 +/- 18.3, LOS: 100.0 %, DrawRatio: 30.2 %
1000 of 1000 games finished.
```