### PR TITLE
Improve nmp (34.1 +/- 22.7)

### DIFF
--- a/chess/src/board.rs
+++ b/chess/src/board.rs
@@ -345,6 +345,19 @@ impl Board {
 
         false
     }
+
+    /// Check whether Zugzwang is unlikely
+    ///
+    /// Very rudimentary check: if we have pieces on the board besides pawns 
+    /// and a king, it's probably not zugzwang.
+    pub fn zugzwang_unlikely(&self) -> bool {
+        let us = self.current;
+        let ours = self.occupied_by(us);
+        let pawns = self.pawns(us);
+        let king = self.kings(us);
+
+        ours != pawns | king
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -1,3 +1,5 @@
+use crate::search::params::NMP_BASE_REDUCTION;
+use crate::search::params::NMP_REDUCTION_FACTOR;
 use crate::transpositions::NodeType;
 use crate::transpositions::TTEntry;
 use crate::search_tables::PVTable;
@@ -15,7 +17,6 @@ use super::params::HISTORY_TABLE;
 use super::params::KILLER_MOVES;
 use super::params::MAX_DEPTH;
 use super::params::NULL_MOVE_PRUNING;
-use super::params::NULL_MOVE_REDUCTION;
 use super::params::QUIESCENCE_SEARCH;
 use super::params::RFP_MARGIN;
 use super::params::RFP_THRESHOLD;
@@ -178,14 +179,12 @@ impl Position {
         //
         ////////////////////////////////////////////////////////////////////////
 
-        const NMP_BASE_REDUCTION: usize = 4;
-        const NMP_REDUCTION_FACTOR: usize = 4;
-
         let should_null_prune = NULL_MOVE_PRUNING 
             && try_null
             && !PV
             && !in_root
-            && !in_check;
+            && !in_check
+            && self.board.zugzwang_unlikely();
 
         if should_null_prune {
             let reduction = (NMP_BASE_REDUCTION + depth / NMP_REDUCTION_FACTOR)

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -178,20 +178,24 @@ impl Position {
         //
         ////////////////////////////////////////////////////////////////////////
 
+        const NMP_BASE_REDUCTION: usize = 4;
+        const NMP_REDUCTION_FACTOR: usize = 4;
+
         let should_null_prune = NULL_MOVE_PRUNING 
             && try_null
             && !PV
             && !in_root
-            && !in_check
-            && !PV
-            && depth >= NULL_MOVE_REDUCTION + 1;
+            && !in_check;
 
         if should_null_prune {
+            let reduction = (NMP_BASE_REDUCTION + depth / NMP_REDUCTION_FACTOR)
+                .min(depth);
+
             let score = -self
                 .play_move(Move::NULL)
                 .zero_window(
                     ply + 1, 
-                    depth - 1 - NULL_MOVE_REDUCTION, 
+                    depth - reduction,
                     -beta + 1, 
                     tt, 
                     &mut PVTable::new(), 

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -26,7 +26,8 @@ pub const DEBUG            : bool = true;
 pub const MAX_DEPTH           : usize = 128;
 
 // Null-move pruning
-pub const NULL_MOVE_REDUCTION : usize = 3;
+pub const NMP_BASE_REDUCTION: usize = 4;
+pub const NMP_REDUCTION_FACTOR: usize = 4;
 
 // Aspiration search
 pub const ASPIRATION_MIN_DEPTH: usize = 4;


### PR DESCRIPTION
Make NMP reduction depth-dependent.

Also adds a quick Zugzwang check I nicked from Carp and Viri (if there's pieces other than king and pawns left, you're probably not in zugzwang).

```
Score of Simbelmyne vs Simbelmyne main: 224 - 166 - 204 [0.549]
...      Simbelmyne playing White: 154 - 48 - 95  [0.678] 297
...      Simbelmyne playing Black: 70 - 118 - 109  [0.419] 297
...      White vs Black: 272 - 118 - 204  [0.630] 594
Elo difference: 34.0 +/- 22.7, LOS: 99.8 %, DrawRatio: 34.3 %
600 of 1000 games finished.
```