### PR TITLE
Improve quiet history (26.8 +/- 16.9)

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -9,7 +9,7 @@
 
 ## Pruning
 - [ ] Delta pruning
-- [ ] More sophisticated null-move pruning, add Zugzwang check
+- [✓] More sophisticated null-move pruning, add Zugzwang check
 - [ ] SEE pruning
 - [ ] Razoring
 

--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -274,7 +274,7 @@ impl<'pos> MovePicker<'pos> {
             } 
 
             let piece = self.position.board.get_at(mv.src()).unwrap();
-            self.scores[i] += history_table.get(mv, piece);
+            self.scores[i] += history_table.get(mv, piece) as i32;
         }
     }
 }

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -52,7 +52,7 @@ pub const RFP_MARGIN: Eval = 80;
 pub const MAX_KILLERS: usize = 2;
 
 // History table
-pub const HIST_AGE_DIVISOR: i32 = 4;
+pub const HIST_AGE_DIVISOR: i16 = 4;
 
 // Late move pruning
 pub const LMP_THRESHOLD: usize = 8;


### PR DESCRIPTION
More sophisticated scoring, deduct scores for bad quiets tried

```
Score of Simbelmyne vs Simbelmyne main: 346 - 269 - 385 [0.538]
...      Simbelmyne playing White: 208 - 106 - 186  [0.602] 500
...      Simbelmyne playing Black: 138 - 163 - 199  [0.475] 500
...      White vs Black: 371 - 244 - 385  [0.564] 1000
Elo difference: 26.8 +/- 16.9, LOS: 99.9 %, DrawRatio: 38.5 %
1000 of 1000 games finished.
```