### PR TITLE
Default to 100ms when wtime/btime is unparsable

### DIFF
--- a/uci/src/time_control.rs
+++ b/uci/src/time_control.rs
@@ -99,13 +99,16 @@ impl FromStr for TimeControl {
             "wtime" => {
                 let wtime: u64 = parts.next()
                     .ok_or(anyhow!("Invalid time control: {s}"))?
-                    .parse()?;
+                    .parse()
+                    .unwrap_or(100);
 
                 let _ = parts.next();
 
                 let btime: u64 = parts.next()
                     .ok_or(anyhow!("Invalid time control: {s}"))?
-                    .parse()?;
+                    .parse()
+                    .unwrap_or(100);
+
 
                 let mut winc = None;
                 let mut binc = None;


### PR DESCRIPTION
Fix an issue we were seeing in CCRL tournament where we got handed a 
```
go wtime 177576 btime -78 winc 8000 binc 8000
```
