### PR TITLE
Add separate `Score::move_piece` helper

### DIFF
--- a/simbelmyne/src/evaluate/mod.rs
+++ b/simbelmyne/src/evaluate/mod.rs
@@ -257,6 +257,30 @@ impl Score {
         self.game_phase -= piece.game_phase();
     }
 
+    /// Update the score by moving a piece from one square to another
+    pub fn update(&mut self, piece: Piece, from: Square, to: Square, board: &Board) {
+        self.mg_score -= piece.mg_score(from);
+        self.eg_score -= piece.eg_score(from);
+        self.mg_score += piece.mg_score(to);
+        self.eg_score += piece.eg_score(to);
+
+        if piece.is_pawn() {
+            self.update_passed_pawns(board);
+            self.update_isolated_pawns(board);
+            self.update_doubled_pawns(board);
+        }
+
+        if piece.is_bishop() {
+            self.update_bishop_pair(board);
+        }
+
+        if piece.is_rook() {
+            self.update_rook_open_file(board);
+        }
+
+        self.update_mobility(board);
+    }
+
     fn update_passed_pawns(&mut self, board: &Board) {
         use Color::*;
         let white_pawns = board.pawns(White);

--- a/simbelmyne/src/position.rs
+++ b/simbelmyne/src/position.rs
@@ -132,8 +132,12 @@ impl Position {
           .expect("The target square of a move is occupied after playing");
 
         // Update the score
-        new_score.remove(old_piece, mv.src(), &new_board);
-        new_score.add(new_piece, mv.tgt(), &new_board);
+        if mv.is_promotion() {
+            new_score.remove(old_piece, mv.src(), &new_board);
+            new_score.add(new_piece, mv.tgt(), &new_board);
+        } else {
+            new_score.update(old_piece, mv.src(), mv.tgt(), &new_board);
+        }
 
         // Update the hash
         new_hash.toggle_piece(old_piece, mv.src());
@@ -164,16 +168,15 @@ impl Position {
         if mv.is_castle() {
             let ctype = CastleType::from_move(mv).unwrap();
             let rook_move = ctype.rook_move();
-            let piece = self.board.piece_list[rook_move.src() as usize]
+            let rook = self.board.piece_list[rook_move.src() as usize]
                 .expect("We know there is a rook at the starting square");
 
             // Update the score
-            new_score.remove(piece, rook_move.src(), &new_board);
-            new_score.add(piece, rook_move.tgt(), &new_board);
+            new_score.update(rook, rook_move.src(), rook_move.tgt(), &new_board);
 
             // Update the hash
-            new_hash.toggle_piece(piece, rook_move.src());
-            new_hash.toggle_piece(piece, rook_move.tgt());
+            new_hash.toggle_piece(rook, rook_move.src());
+            new_hash.toggle_piece(rook, rook_move.tgt());
         }
 
         // Invalidate the previous castling rights, even if the move wasn't a 


### PR DESCRIPTION
More efficient than always going through `Score::add` and `Score::remove`, since it recomputes all of the evaluation terms twice.

Not the most significant Elo, but it leads to a ~20% speedup, so definitely worth keeping

```
Score of Simbelmyne vs Simbelmyne main: 747 - 688 - 797 [0.513]
...      Simbelmyne playing White: 420 - 282 - 414  [0.562] 1116
...      Simbelmyne playing Black: 327 - 406 - 383  [0.465] 1116
...      White vs Black: 826 - 609 - 797  [0.549] 2232
Elo difference: 9.2 +/- 11.5, LOS: 94.0 %, DrawRatio: 35.7 %
2232 of 2500 games finished.
```