### PR TITLE
Chess/store pinrays

### DIFF
--- a/chess/src/board.rs
+++ b/chess/src/board.rs
@@ -232,15 +232,13 @@ impl Board {
     }
 
     /// Compute the pin rays that are pinning the current player's pieces.
-    pub fn pinrays(&self) -> Vec<Bitboard> {
+    pub fn pinrays(&self) -> Bitboard {
         // Idea: 
         // See how many of the opponent's sliders are checking our king if all
         // our pieces weren't there. Then check whether those rays contain a 
         // single piece. If so, it's pinned. (Note that it would be, by 
         // necessity, one of our pieces, since otherwise the king couldn't have 
         // been in check)
-        // TODO: Can we be smarter here and look for all the checkers, and
-        // return the BETWEEN lookups instead?
         let us = self.current;
         let them = !us;
         let king_sq = self.kings(us).first();
@@ -250,7 +248,7 @@ impl Board {
         let diag_sliders = self.diag_sliders(them);
         let hv_sliders = self.hv_sliders(them);
 
-        let mut pinrays: Vec<Bitboard> = Vec::new();
+        let mut pinrays = Bitboard::EMPTY;
 
         let potential_pinners = king_sq.rook_squares(theirs) & hv_sliders
             | king_sq.bishop_squares(theirs) & diag_sliders;
@@ -260,7 +258,7 @@ impl Board {
             ray |= Bitboard::from(pinner);
 
             if (ray & ours).count() == 1 {
-                pinrays.push(ray);
+                pinrays |= ray;
             }
         }
 

--- a/chess/src/board.rs
+++ b/chess/src/board.rs
@@ -42,6 +42,8 @@ pub struct Board {
     /// The number of full turns
     /// Starts at one, and is incremented after every Black move
     pub full_moves: u16,
+
+    pub pinrays: [Bitboard; Color::COUNT],
 }
 
 impl Board {
@@ -232,14 +234,13 @@ impl Board {
     }
 
     /// Compute the pin rays that are pinning the current player's pieces.
-    pub fn pinrays(&self) -> Bitboard {
+    pub fn pinrays(&self, us: Color) -> Bitboard {
         // Idea: 
         // See how many of the opponent's sliders are checking our king if all
         // our pieces weren't there. Then check whether those rays contain a 
         // single piece. If so, it's pinned. (Note that it would be, by 
         // necessity, one of our pieces, since otherwise the king couldn't have 
         // been in check)
-        let us = self.current;
         let them = !us;
         let king_sq = self.kings(us).first();
 
@@ -428,7 +429,7 @@ impl Board {
         let en_passant = self.en_passant.map(|ep| ep.flip());
         let current = self.current.opp();
 
-        Self {
+        let mut mirrored = Self {
             current,
             piece_list,
             occupied_squares,
@@ -437,7 +438,15 @@ impl Board {
             en_passant,
             half_moves: self.half_moves,
             full_moves: self.full_moves,
-        }
+            pinrays: [Bitboard::EMPTY; 2]
+        };
+
+        mirrored.pinrays = [
+            mirrored.pinrays(Color::White),
+            mirrored.pinrays(Color::Black),
+        ];
+
+        mirrored
     }
 }
 

--- a/chess/src/fen.rs
+++ b/chess/src/fen.rs
@@ -152,7 +152,7 @@ impl Board {
             .ok_or(anyhow!("Invalid FEN string"))?
             .parse()?;
 
-        Ok(Board {
+        let mut board = Board {
             piece_list,
             piece_bbs,
             occupied_squares,
@@ -161,7 +161,15 @@ impl Board {
             en_passant,
             half_moves,
             full_moves,
-        })
+            pinrays: [Bitboard::EMPTY; 2]
+        };
+
+        board.pinrays = [
+            board.pinrays(Color::White),
+            board.pinrays(Color::Black),
+        ];
+
+        Ok(board)
     }
 }
 

--- a/chess/src/movegen/legal_moves.rs
+++ b/chess/src/movegen/legal_moves.rs
@@ -27,7 +27,7 @@ impl Board {
     pub fn legal_moves<const QUIETS: bool>(&self) -> Vec<Move> {
         let us = self.current;
         let checkers = self.checkers();
-        let pinrays = self.pinrays();
+        let pinrays = self.pinrays[us as usize];
         let mut moves: Vec<Move> = Vec::with_capacity(50);
 
         // Add the king moves to the list of legal moves

--- a/chess/src/movegen/play_move.rs
+++ b/chess/src/movegen/play_move.rs
@@ -145,6 +145,11 @@ impl Board {
             _ => {}
         }
 
+        new_board.pinrays = [
+            new_board.pinrays(Color::White),
+            new_board.pinrays(Color::Black),
+        ];
+
         new_board
     }
 }


### PR DESCRIPTION
Doesn't gain or lose, but could be useful to store the pinrays on the board, so we can use them in eval, etc... for free.

Also, gets rid of an allocation for the vec of pinrays, which I was hoping would give us a speed boost, but doesn't seem to have any measurable effect.