### PR TITLE
Uci options

### DIFF
--- a/simbelmyne/src/cli/bench.rs
+++ b/simbelmyne/src/cli/bench.rs
@@ -1,7 +1,7 @@
 use colored::Colorize;
 use uci::time_control::TimeControl;
 
-use crate::{position::Position, transpositions::TTable, time_control::TimeController, search_tables::HistoryTable};
+use crate::{position::Position, transpositions::TTable, time_control::TimeController, search_tables::HistoryTable, search::params::SearchParams};
 
 use super::presets::Preset;
 pub fn run_bench(depth: usize, fen: Option<String>) {
@@ -20,7 +20,8 @@ pub fn run_single(fen: &str, depth: usize) {
     let mut tt = TTable::with_capacity(64);
     let (tc, _handle) = TimeController::new(TimeControl::Depth(depth), board);
     let mut history = HistoryTable::new();
-    let search = position.search(&mut tt, &mut history, tc);
+    let search_params = SearchParams::default();
+    let search = position.search(&mut tt, &mut history, tc, &search_params);
 
     println!("{board}");
     println!("{:17} {}", "FEN:".green(), fen);

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -98,6 +98,7 @@ impl Position {
     pub fn search(&self, tt: &mut TTable, history: &mut HistoryTable, tc: TimeController, search_params: &SearchParams) -> SearchReport {
         let mut depth = 1;
         let mut latest_report = SearchReport::default();
+        println!("Searching with: {search_params:?}");
 
         while depth <= MAX_DEPTH && tc.should_start_search(depth) {
             let mut pv = PVTable::new();

--- a/simbelmyne/src/search/aspiration.rs
+++ b/simbelmyne/src/search/aspiration.rs
@@ -16,7 +16,7 @@
 //! more than compensates for the odd re-search.
 use crate::{position::Position, evaluate::{Score, Eval}, transpositions::TTable, search_tables::PVTable};
 
-use super::{Search, params::{ASPIRATION_MAX_WINDOW, ASPIRATION_MIN_DEPTH, ASPIRATION_BASE_WINDOW}};
+use super::Search;
 
 impl Position {
     /// Perform an alpha-beta search with aspiration window centered on `guess`.
@@ -30,9 +30,9 @@ impl Position {
     ) -> Score {
         let mut alpha = Eval::MIN;
         let mut beta = Eval::MAX;
-        let mut width = ASPIRATION_BASE_WINDOW;
+        let mut width = search.search_params.aspiration_base_window;
 
-        if depth >= ASPIRATION_MIN_DEPTH {
+        if depth >= search.search_params.aspiration_min_depth {
             alpha = Score::max(Eval::MIN, guess - width);
             beta = Score::min(Eval::MAX, guess + width);
         }
@@ -63,7 +63,7 @@ impl Position {
 
             // If the window exceeds the max width, give up and open the window 
             // up completely.
-            if width > ASPIRATION_MAX_WINDOW {
+            if width > search.search_params.aspiration_max_window {
                 alpha = Eval::MIN;
                 beta = Eval::MAX;
             }

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -13,35 +13,31 @@ use crate::evaluate::Score;
 #[derive(Debug, Clone, Copy)]
 pub struct SearchParams {
     // Null move pruning
-    nmp_base_reduction: usize,
-    nmp_reduction_factor: usize,
+    pub nmp_base_reduction: usize,
+    pub nmp_reduction_factor: usize,
 
     // Aspiration windows
-    aspiration_min_depth: usize,
-    aspiration_base_window: Score,
-    aspiration_max_window: Score,
+    pub aspiration_min_depth: usize,
+    pub aspiration_base_window: Score,
+    pub aspiration_max_window: Score,
 
     // Futility pruning
-    fp_threshold: usize,
-    fp_margins: [Score; 9],
+    pub fp_threshold: usize,
+    pub fp_margins: [Score; 9],
 
     // Reverse futility pruning
-    rfp_threshold: usize,
-    rfp_margin: Score,
-
-    // History tables
-    max_killers: usize,
-    hist_age_divisor: i16,
+    pub rfp_threshold: usize,
+    pub rfp_margin: Score,
 
     // Late move pruning
-    lmp_threshold: usize,
-    lmp_move_thresholds: [usize; 9],
+    pub lmp_threshold: usize,
+    pub lmp_move_thresholds: [usize; 9],
 
     // Late move reductions
-    lmr_min_depth: usize,
-    lmr_threshold: usize,
-    lmr_max_moves: usize,
-    lmr_table: [[usize; LMR_MAX_MOVES]; MAX_DEPTH + 1],
+    pub lmr_min_depth: usize,
+    pub lmr_threshold: usize,
+    pub lmr_max_moves: usize,
+    pub lmr_table: [[usize; LMR_MAX_MOVES]; MAX_DEPTH + 1],
 }
 
 impl Default for SearchParams {
@@ -63,10 +59,6 @@ impl Default for SearchParams {
             // Reverse futility pruning
             rfp_threshold: RFP_THRESHOLD,
             rfp_margin: RFP_MARGIN,
-
-            // History tables
-            max_killers: MAX_KILLERS,
-            hist_age_divisor: HIST_AGE_DIVISOR,
 
             // Late move pruning
             lmp_threshold: LMP_THRESHOLD,
@@ -108,21 +100,21 @@ pub const DEBUG            : bool = true;
 pub const MAX_DEPTH           : usize = 128;
 
 // Null-move pruning
-pub const NMP_BASE_REDUCTION: usize = 4;
-pub const NMP_REDUCTION_FACTOR: usize = 4;
+const NMP_BASE_REDUCTION: usize = 4;
+const NMP_REDUCTION_FACTOR: usize = 4;
 
 // Aspiration search
-pub const ASPIRATION_MIN_DEPTH: usize = 4;
-pub const ASPIRATION_BASE_WINDOW: Score = 30;
-pub const ASPIRATION_MAX_WINDOW: Score = 900;
+const ASPIRATION_MIN_DEPTH: usize = 4;
+const ASPIRATION_BASE_WINDOW: Score = 30;
+const ASPIRATION_MAX_WINDOW: Score = 900;
 
 // Futility pruning
-pub const FP_THRESHOLD: usize = 8;
-pub const FP_MARGINS: [Score; 9] = [0, 100, 160, 220, 280, 340, 400, 460, 520];
+const FP_THRESHOLD: usize = 8;
+const FP_MARGINS: [Score; 9] = [0, 100, 160, 220, 280, 340, 400, 460, 520];
 
 // Reverse futility pruning
-pub const RFP_THRESHOLD: usize = 8;
-pub const RFP_MARGIN: Score = 80;
+const RFP_THRESHOLD: usize = 8;
+const RFP_MARGIN: Score = 80;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -136,9 +128,14 @@ pub const MAX_KILLERS: usize = 2;
 // History table
 pub const HIST_AGE_DIVISOR: i16 = 4;
 
+////////////////////////////////////////////////////////////////////////////////
+//
 // Late move pruning
-pub const LMP_THRESHOLD: usize = 8;
-pub const LMP_MOVE_THRESHOLDS: [usize; 9] = [0, 5, 8, 13, 20, 29, 40, 53, 68];
+//
+////////////////////////////////////////////////////////////////////////////////
+
+const LMP_THRESHOLD: usize = 8;
+const LMP_MOVE_THRESHOLDS: [usize; 9] = [0, 5, 8, 13, 20, 29, 40, 53, 68];
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -147,11 +144,11 @@ pub const LMP_MOVE_THRESHOLDS: [usize; 9] = [0, 5, 8, 13, 20, 29, 40, 53, 68];
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-pub const LMR_MIN_DEPTH: usize = 3;
-pub const LMR_THRESHOLD: usize = 3;
+const LMR_MIN_DEPTH: usize = 3;
+const LMR_THRESHOLD: usize = 3;
 
-pub const LMR_MAX_MOVES: usize = 256;
-pub const LMR_TABLE: [[usize; LMR_MAX_MOVES]; MAX_DEPTH + 1] = lmr_table();
+const LMR_MAX_MOVES: usize = 256;
+const LMR_TABLE: [[usize; LMR_MAX_MOVES]; MAX_DEPTH + 1] = lmr_table();
 
 const fn lmr_table() -> [[usize; LMR_MAX_MOVES]; MAX_DEPTH + 1] {
     let mut lmr_table = [[0; LMR_MAX_MOVES]; MAX_DEPTH + 1];

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -2,6 +2,88 @@ use crate::evaluate::Score;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
+// SearchParams struct
+//
+// Enables the engine to dynamically set the values for the search parameters,
+// for example through UCI options
+// 
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Clone, Copy)]
+pub struct SearchParams {
+    // Null move pruning
+    nmp_base_reduction: usize,
+    nmp_reduction_factor: usize,
+
+    // Aspiration windows
+    aspiration_min_depth: usize,
+    aspiration_base_window: Score,
+    aspiration_max_window: Score,
+
+    // Futility pruning
+    fp_threshold: usize,
+    fp_margins: [Score; 9],
+
+    // Reverse futility pruning
+    rfp_threshold: usize,
+    rfp_margin: Score,
+
+    // History tables
+    max_killers: usize,
+    hist_age_divisor: i16,
+
+    // Late move pruning
+    lmp_threshold: usize,
+    lmp_move_thresholds: [usize; 9],
+
+    // Late move reductions
+    lmr_min_depth: usize,
+    lmr_threshold: usize,
+    lmr_max_moves: usize,
+    lmr_table: [[usize; LMR_MAX_MOVES]; MAX_DEPTH + 1],
+}
+
+impl Default for SearchParams {
+    fn default() -> Self {
+        Self {
+            // Null move pruning
+            nmp_base_reduction: NMP_BASE_REDUCTION,
+            nmp_reduction_factor: NMP_REDUCTION_FACTOR,
+
+            // Aspiration windows
+            aspiration_min_depth: ASPIRATION_MIN_DEPTH,
+            aspiration_base_window: ASPIRATION_BASE_WINDOW,
+            aspiration_max_window: ASPIRATION_MAX_WINDOW,
+
+            // Futility pruning
+            fp_threshold: FP_THRESHOLD,
+            fp_margins: FP_MARGINS,
+
+            // Reverse futility pruning
+            rfp_threshold: RFP_THRESHOLD,
+            rfp_margin: RFP_MARGIN,
+
+            // History tables
+            max_killers: MAX_KILLERS,
+            hist_age_divisor: HIST_AGE_DIVISOR,
+
+            // Late move pruning
+            lmp_threshold: LMP_THRESHOLD,
+            lmp_move_thresholds: LMP_MOVE_THRESHOLDS,
+
+            // Late move reductions
+            lmr_min_depth: LMR_MIN_DEPTH,
+            lmr_threshold: LMR_THRESHOLD,
+            lmr_max_moves: LMR_MAX_MOVES,
+            lmr_table: LMR_TABLE
+        }
+    }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+//
 // Search options
 //
 ////////////////////////////////////////////////////////////////////////////////

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -16,6 +16,7 @@ use colored::Colorize;
 use uci::client::UciClientMessage;
 use uci::options::OptionType;
 use uci::options::UciOption;
+use crate::search::params::SearchParams;
 use crate::search_tables::HistoryTable;
 use crate::time_control::TimeController;
 use crate::time_control::TimeControlHandle;
@@ -188,13 +189,14 @@ impl SearchThread {
         std::thread::spawn(move || {
             let mut tt = TTable::with_capacity(64);
             let mut history = HistoryTable::new();
+            let search_params = SearchParams::default();
 
             for msg in rx.iter() {
                 match msg {
                     SearchCommand::Search(position, tc) => {
                         history.age_entries();
                         tt.increment_age();
-                        position.search(&mut tt, &mut history, tc);
+                        position.search(&mut tt, &mut history, tc, &search_params);
                     },
 
                     SearchCommand::Clear => {

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -16,6 +16,7 @@ use colored::Colorize;
 use uci::client::UciClientMessage;
 use uci::options::OptionType;
 use uci::options::UciOption;
+use crate::evaluate::Score;
 use crate::search::params::SearchParams;
 use crate::search_tables::HistoryTable;
 use crate::time_control::TimeController;
@@ -46,6 +47,7 @@ pub struct SearchController {
     debug: bool,
     tc_handle: Option<TimeControlHandle>,
     search_thread: SearchThread,
+    search_params: SearchParams,
 }
 
 const UCI_OPTIONS: [UciOption; 1] = [
@@ -60,6 +62,7 @@ impl SearchController {
             debug: false,
             tc_handle: None,
             search_thread: SearchThread::new(),
+            search_params: SearchParams::default(),
         }
     }
 
@@ -142,9 +145,185 @@ impl SearchController {
                         // Set an option
                         UciClientMessage::SetOption(name, value) => {
                             match name.as_str() {
+                                // Advertized options
                                 "Hash" => {
                                     let size: usize = value.parse()?;
                                     self.search_thread.resize_tt(size);
+                                },
+
+                                // Internal options, for SPSA tuning
+                                "nmp_base_reduction" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.nmp_base_reduction = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "nmp_reduction_factor" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.nmp_reduction_factor = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "aspiration_min_depth" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.aspiration_min_depth = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "aspiration_base_window" => {
+                                    let value: Score = value.parse()?;
+                                    self.search_params.aspiration_base_window = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "aspiration_max_window" => {
+                                    let value: Score = value.parse()?;
+                                    self.search_params.aspiration_max_window = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "fp_threshold" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.fp_threshold = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "fp_margins0" => {
+                                    let value: Score = value.parse()?;
+                                    self.search_params.fp_margins[0] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "fp_margins1" => {
+                                    let value: Score = value.parse()?;
+                                    self.search_params.fp_margins[1] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "fp_margins2" => {
+                                    let value: Score = value.parse()?;
+                                    self.search_params.fp_margins[2] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "fp_margins3" => {
+                                    let value: Score = value.parse()?;
+                                    self.search_params.fp_margins[3] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "fp_margins4" => {
+                                    let value: Score = value.parse()?;
+                                    self.search_params.fp_margins[4] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "fp_margins5" => {
+                                    let value: Score = value.parse()?;
+                                    self.search_params.fp_margins[5] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "fp_margins6" => {
+                                    let value: Score = value.parse()?;
+                                    self.search_params.fp_margins[6] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "fp_margins7" => {
+                                    let value: Score = value.parse()?;
+                                    self.search_params.fp_margins[7] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "fp_margins8" => {
+                                    let value: Score = value.parse()?;
+                                    self.search_params.fp_margins[8] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "rfp_threshold" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.rfp_threshold = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "rfp_margin" => {
+                                    let value: Score = value.parse()?;
+                                    self.search_params.rfp_margin = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "lmp_threshold" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.lmp_threshold = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "lmp_move_thresholds0" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.lmp_move_thresholds[0] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "lmp_move_thresholds1" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.lmp_move_thresholds[1] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "lmp_move_thresholds2" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.lmp_move_thresholds[2] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "lmp_move_thresholds3" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.lmp_move_thresholds[3] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "lmp_move_thresholds4" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.lmp_move_thresholds[4] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "lmp_move_thresholds5" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.lmp_move_thresholds[5] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "lmp_move_thresholds6" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.lmp_move_thresholds[6] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "lmp_move_thresholds7" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.lmp_move_thresholds[7] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "lmp_move_thresholds8" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.lmp_move_thresholds[8] = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "lmr_min_depth" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.lmr_min_depth = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "lmr_threshold" => {
+                                    let value: usize = value.parse()?;
+                                    self.search_params.lmr_threshold = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
                                 },
 
                                 _ => {}
@@ -172,6 +351,7 @@ enum SearchCommand {
     Search(Position, TimeController),
     Clear,
     ResizeTT(usize),
+    SetSearchParams(SearchParams),
 }
 
 /// A handle to a long-running thread that's in charge of searching for the best
@@ -189,7 +369,7 @@ impl SearchThread {
         std::thread::spawn(move || {
             let mut tt = TTable::with_capacity(64);
             let mut history = HistoryTable::new();
-            let search_params = SearchParams::default();
+            let mut search_params = SearchParams::default();
 
             for msg in rx.iter() {
                 match msg {
@@ -206,6 +386,10 @@ impl SearchThread {
 
                     SearchCommand::ResizeTT(size) => {
                         tt = TTable::with_capacity(size);
+                    }
+
+                    SearchCommand::SetSearchParams(params) => {
+                        search_params = params;
                     }
                 }
             }
@@ -226,5 +410,9 @@ impl SearchThread {
 
     pub fn resize_tt(&self, size: usize) {
         self.tx.send(SearchCommand::ResizeTT(size)).unwrap();
+    }
+
+    pub fn set_search_params(&self, search_params: SearchParams) {
+        self.tx.send(SearchCommand::SetSearchParams(search_params)).unwrap();
     }
 }

--- a/uci/src/client.rs
+++ b/uci/src/client.rs
@@ -71,21 +71,20 @@ impl FromStr for UciClientMessage {
 
             "setoption" => {
                 let mut parts = remainder.split_whitespace();
-                parts.next(); // Skip "name"
-                let opt = if let Some(opt) = parts.next() {
-                    opt
-                } else {
-                    Err(anyhow!("Invalid UCI message: {msg}"))?
-                };
+                assert_eq!(parts.next(), Some("name"), "Invalidly formed UCI command");
+                
+                let name = parts
+                    .by_ref()
+                    .take_while(|&word| word != "value")
+                    .collect::<String>();
 
-                parts.next(); // Skip "value"
                 let value  = if let Some(value) = parts.next() {
                     value
                 } else {
                     Err(anyhow!("Invalid UCI message"))?
                 };
 
-                Ok(SetOption(opt.to_string(), value.to_string()))
+                Ok(SetOption(name.to_string(), value.to_string()))
             },
 
             "ucinewgame" => Ok(UciNewGame),

--- a/uci/src/engine.rs
+++ b/uci/src/engine.rs
@@ -1,6 +1,6 @@
 use std::{str::FromStr, fmt::Display};
 use chess::movegen::moves::Move;
-use crate::search_info::SearchInfo;
+use crate::{search_info::SearchInfo, options::UciOption};
 use anyhow::anyhow;
 
 /// Messages that can be sent from the engine back to the client
@@ -10,7 +10,8 @@ pub enum UciEngineMessage {
     UciOk,
     ReadyOk,
     BestMove(Move),
-    Info(SearchInfo)
+    Info(SearchInfo),
+    UciOption(UciOption)
 }
 
 impl FromStr for UciEngineMessage {
@@ -60,6 +61,7 @@ impl Display for UciEngineMessage {
             ReadyOk => write!(f, "readyok"),
             BestMove(mv) => write!(f, "bestmove {mv}"),
             Info(info) => write!(f, "info {info}"),
+            UciOption(option) => write!(f, "option {option}"),
         }
     }
 }

--- a/uci/src/lib.rs
+++ b/uci/src/lib.rs
@@ -5,3 +5,4 @@ pub mod client;
 pub mod engine;
 pub mod time_control;
 pub mod search_info;
+pub mod options;

--- a/uci/src/options.rs
+++ b/uci/src/options.rs
@@ -1,0 +1,54 @@
+use std::fmt::Display;
+
+#[derive(Debug, Clone)]
+pub enum OptionType {
+    Check { default: bool },
+    Spin { min: i32, max: i32, default: i32 },
+    Combo { default: String, allowed: Vec<String> },
+    Button,
+    String { default: String },
+}
+
+impl Display for OptionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Check { default } => {
+                write!(f, "type check default {default}")?;
+            },
+
+            Self::Spin { min, max, default } => {
+                write!(f, "type spin default {default} min {min} max {max}")?;
+            }
+
+            Self::Combo { default, allowed }=> {
+                write!(f, "type combo default {default} ")?;
+
+                for value in allowed {
+                    write!(f, "var {value} ")?;
+                }
+            },
+
+            Self::Button => {
+                write!(f, "type button")?;
+            },
+
+            Self::String { default } => {
+                write!(f, "type string default {default}")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UciOption {
+    pub name: &'static str,
+    pub option_type: OptionType,
+}
+
+impl Display for UciOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "name {} {}", self.name, self.option_type)
+    }
+}


### PR DESCRIPTION
Add the ability to set hash size and tuneable parameters through UCI options.

Only the `Hash` option is advertised through the UCI protocol, though. Tuneable search parameters are only available for internal use.