### PR TITLE
🐛 Illegal pv moves

### DIFF
--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -86,9 +86,6 @@ impl Position {
         let mut tt_move = tt_entry.map(|entry| entry.get_move());
         let mut local_pv = PVTable::new();
 
-        pv.clear();
-        search.tc.add_node();
-
         // Rule-based draw? 
         // Don't return early when in the root node, because we won't have a PV 
         // move to play.

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -32,6 +32,7 @@ impl Position {
         }
 
         search.tc.add_node();
+        pv.clear();
 
         search.seldepth = search.seldepth.max(ply);
 


### PR DESCRIPTION
Wasn't clearing the passed in `pv` array in quiescence search, meaning there was some junk moves in there.