### PR TITLE
Zero allocations (13.8 +/- 12.7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,10 +57,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "chess"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "itertools",
 ]
 
@@ -215,6 +222,7 @@ name = "simbelmyne"
 version = "1.3.1"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "chess",
  "clap",
  "colored",

--- a/chess/Cargo.toml
+++ b/chess/Cargo.toml
@@ -11,4 +11,5 @@ path = "./src/utils/gen_magics.rs"
 
 [dependencies]
 anyhow = "1.0.75"
+arrayvec = "0.7.4"
 itertools = "0.11.0"

--- a/chess/src/array_vec.rs
+++ b/chess/src/array_vec.rs
@@ -1,0 +1,81 @@
+use std::ops::{Deref, DerefMut};
+
+#[derive(Debug, Clone)]
+pub struct ArrayVec<T, const SIZE: usize> {
+    moves: [T; SIZE],
+    len: usize,
+}
+
+impl<T, const SIZE: usize> ArrayVec<T, SIZE> where T: Copy + Clone + Default {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push(&mut self, mv: T) {
+        self.moves[self.len] = mv;
+        self.len += 1;
+    }
+
+    pub fn clear(&mut self) {
+        self.len = 0;
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl<T, const SIZE: usize> Default for ArrayVec<T, SIZE> where T: Copy + Clone + Default {
+    fn default() -> Self {
+        Self {
+            moves: [T::default(); SIZE],
+            len: 0,
+        }
+    }
+}
+
+impl<T, const SIZE: usize> IntoIterator for ArrayVec<T, SIZE> where T: Copy + Clone {
+    type Item = T;
+
+    type IntoIter = IntoIter<T, SIZE>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Self::IntoIter {
+            inner: self,
+            idx: 0
+        }
+    }
+}
+
+impl<T, const SIZE: usize> Deref for ArrayVec<T, SIZE> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        &self.moves
+    }
+}
+
+impl<T, const SIZE: usize> DerefMut for ArrayVec<T, SIZE> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.moves
+    }
+}
+
+pub struct IntoIter<T, const SIZE: usize> {
+    inner: ArrayVec<T, SIZE>,
+    idx: usize,
+}
+
+impl<T, const SIZE: usize> Iterator for IntoIter<T, SIZE> where T: Copy + Clone {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx < self.inner.len {
+            let mv = self.inner[self.idx];
+            self.idx += 1;
+            Some(mv)
+        } else {
+            None
+        }
+    }
+}

--- a/chess/src/lib.rs
+++ b/chess/src/lib.rs
@@ -7,3 +7,4 @@ pub mod constants;
 pub mod fen;
 pub mod magics;
 pub mod see;
+pub mod array_vec;

--- a/chess/src/lib.rs
+++ b/chess/src/lib.rs
@@ -7,4 +7,3 @@ pub mod constants;
 pub mod fen;
 pub mod magics;
 pub mod see;
-pub mod array_vec;

--- a/chess/src/movegen/legal_moves.rs
+++ b/chess/src/movegen/legal_moves.rs
@@ -6,6 +6,7 @@
 //! All the move generating functions are parametrized by a `QUIETS` const
 //! generic that decides whether or not to include quiet moves.
 
+use crate::array_vec::ArrayVec;
 use crate::constants::RANKS;
 use crate::square::Square;
 use crate::{
@@ -17,19 +18,21 @@ use crate::movegen::lookups::{BETWEEN, RAYS};
 use crate::movegen::moves::Move;
 use crate::piece::PieceType;
 
-use super::move_array::MoveArray;
 use super::moves::BareMove;
 
 const NO_KING: bool = false;
 const QUIETS: bool = true;
 
+pub const MAX_MOVES: usize = 218;
+pub type MoveList = ArrayVec<Move, MAX_MOVES>;
+
 impl Board {
     /// Find all the legal moves for the current board state
-    pub fn legal_moves<const QUIETS: bool>(&self) -> MoveArray {
+    pub fn legal_moves<const QUIETS: bool>(&self) -> MoveList {
         let us = self.current;
         let checkers = self.checkers();
         let pinrays = self.pinrays[us as usize];
-        let mut moves: MoveArray = MoveArray::new();
+        let mut moves: MoveList = MoveList::new();
 
         // Add the king moves to the list of legal moves
         for square in self.kings(us) {
@@ -64,7 +67,7 @@ impl Board {
     fn pawn_moves<const QUIETS: bool>(
         &self, 
         square: Square, 
-        moves: &mut MoveArray,
+        moves: &mut MoveList,
         checkers: Bitboard, 
         pinrays: Bitboard,
     ) {
@@ -160,7 +163,7 @@ impl Board {
     fn king_moves<const QUIETS: bool>(
         &self,
         square: Square,
-        moves: &mut MoveArray
+        moves: &mut MoveList
     ) {
         use MoveType::*;
         let us = self.current;
@@ -219,7 +222,7 @@ impl Board {
     fn piece_moves<const QUIETS: bool>(
         &self, 
         square: Square,
-        moves: &mut MoveArray,
+        moves: &mut MoveList,
         checkers: Bitboard, 
         pinrays: Bitboard
     ) {
@@ -292,7 +295,7 @@ impl Board {
     fn en_passant_move(
         &self, 
         square: Square, 
-        moves: &mut MoveArray,
+        moves: &mut MoveList,
         checkers: Bitboard
     ) {
         let us = self.current;

--- a/chess/src/movegen/legal_moves.rs
+++ b/chess/src/movegen/legal_moves.rs
@@ -6,7 +6,8 @@
 //! All the move generating functions are parametrized by a `QUIETS` const
 //! generic that decides whether or not to include quiet moves.
 
-use crate::array_vec::ArrayVec;
+use arrayvec::ArrayVec;
+
 use crate::constants::RANKS;
 use crate::square::Square;
 use crate::{

--- a/chess/src/movegen/legal_moves.rs
+++ b/chess/src/movegen/legal_moves.rs
@@ -17,6 +17,7 @@ use crate::movegen::lookups::{BETWEEN, RAYS};
 use crate::movegen::moves::Move;
 use crate::piece::PieceType;
 
+use super::move_array::MoveArray;
 use super::moves::BareMove;
 
 const NO_KING: bool = false;
@@ -24,11 +25,11 @@ const QUIETS: bool = true;
 
 impl Board {
     /// Find all the legal moves for the current board state
-    pub fn legal_moves<const QUIETS: bool>(&self) -> Vec<Move> {
+    pub fn legal_moves<const QUIETS: bool>(&self) -> MoveArray {
         let us = self.current;
         let checkers = self.checkers();
         let pinrays = self.pinrays[us as usize];
-        let mut moves: Vec<Move> = Vec::with_capacity(50);
+        let mut moves: MoveArray = MoveArray::new();
 
         // Add the king moves to the list of legal moves
         for square in self.kings(us) {
@@ -63,7 +64,7 @@ impl Board {
     fn pawn_moves<const QUIETS: bool>(
         &self, 
         square: Square, 
-        moves: &mut Vec<Move>, 
+        moves: &mut MoveArray,
         checkers: Bitboard, 
         pinrays: Bitboard,
     ) {
@@ -159,7 +160,7 @@ impl Board {
     fn king_moves<const QUIETS: bool>(
         &self,
         square: Square,
-        moves: &mut Vec<Move>,
+        moves: &mut MoveArray
     ) {
         use MoveType::*;
         let us = self.current;
@@ -218,7 +219,7 @@ impl Board {
     fn piece_moves<const QUIETS: bool>(
         &self, 
         square: Square,
-        moves: &mut Vec<Move>, 
+        moves: &mut MoveArray,
         checkers: Bitboard, 
         pinrays: Bitboard
     ) {
@@ -291,7 +292,7 @@ impl Board {
     fn en_passant_move(
         &self, 
         square: Square, 
-        moves: &mut Vec<Move>, 
+        moves: &mut MoveArray,
         checkers: Bitboard
     ) {
         let us = self.current;

--- a/chess/src/movegen/mod.rs
+++ b/chess/src/movegen/mod.rs
@@ -3,3 +3,4 @@ pub mod castling;
 pub mod legal_moves;
 pub mod moves;
 pub mod play_move;
+pub mod move_array;

--- a/chess/src/movegen/move_array.rs
+++ b/chess/src/movegen/move_array.rs
@@ -1,0 +1,85 @@
+use std::ops::{Deref, DerefMut};
+
+use super::moves::Move;
+
+#[derive(Debug, Copy, Clone)]
+pub struct MoveArray {
+    moves: [Move; Self::SIZE],
+    len: usize,
+}
+
+impl MoveArray {
+    pub const SIZE: usize = 218;
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push(&mut self, mv: Move) {
+        self.moves[self.len] = mv;
+        self.len += 1;
+    }
+
+    pub fn clear(&mut self) {
+        self.len = 0;
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl Default for MoveArray {
+    fn default() -> Self {
+        Self {
+            moves: [Move::default(); Self::SIZE],
+            len: 0,
+        }
+    }
+}
+
+impl IntoIterator for MoveArray {
+    type Item = Move;
+
+    type IntoIter = IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Self::IntoIter {
+            inner: self,
+            idx: 0
+        }
+    }
+}
+
+impl Deref for MoveArray {
+    type Target = [Move];
+
+    fn deref(&self) -> &Self::Target {
+        &self.moves
+    }
+}
+
+impl DerefMut for MoveArray {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.moves
+    }
+}
+
+pub struct IntoIter {
+    inner: MoveArray,
+    idx: usize,
+}
+
+impl Iterator for IntoIter {
+    type Item = Move;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx < self.inner.len {
+            let mv = self.inner[self.idx];
+            self.idx += 1;
+            Some(mv)
+        } else {
+            None
+        }
+    }
+}

--- a/chess/src/movegen/play_move.rs
+++ b/chess/src/movegen/play_move.rs
@@ -16,7 +16,6 @@ use crate::board::Board;
 use crate::piece::Color;
 use crate::piece::Piece;
 use super::castling::CastleType;
-use super::castling::CastlingRights;
 use super::moves::Move;
 
 impl Board {
@@ -115,11 +114,11 @@ impl Board {
         // If the king moved, revoke their respective castling rights
         if piece.is_king() {
             if self.current.is_white() {
-                new_board.castling_rights.remove(CastlingRights::WQ);
-                new_board.castling_rights.remove(CastlingRights::WK);
+                new_board.castling_rights.remove(CastleType::WQ);
+                new_board.castling_rights.remove(CastleType::WK);
             } else {
-                new_board.castling_rights.remove(CastlingRights::BQ);
-                new_board.castling_rights.remove(CastlingRights::BK);
+                new_board.castling_rights.remove(CastleType::BQ);
+                new_board.castling_rights.remove(CastleType::BK);
             }
         }
 
@@ -127,10 +126,10 @@ impl Board {
         // removesthe castling rights. Otherwise, rook captures wouldn't update 
         // the castling rights correctly.
         match source {
-            A1 => new_board.castling_rights.remove(CastlingRights::WQ),
-            H1 => new_board.castling_rights.remove(CastlingRights::WK),
-            A8 => new_board.castling_rights.remove(CastlingRights::BQ),
-            H8 => new_board.castling_rights.remove(CastlingRights::BK),
+            A1 => new_board.castling_rights.remove(CastleType::WQ),
+            H1 => new_board.castling_rights.remove(CastleType::WK),
+            A8 => new_board.castling_rights.remove(CastleType::BQ),
+            H8 => new_board.castling_rights.remove(CastleType::BK),
             _ => {}
         }
 
@@ -138,10 +137,10 @@ impl Board {
         // the castling rights. Otherwise, rook captures wouldn't update the
         // castling rights correctly.
         match target {
-            A1 => new_board.castling_rights.remove(CastlingRights::WQ),
-            H1 => new_board.castling_rights.remove(CastlingRights::WK),
-            A8 => new_board.castling_rights.remove(CastlingRights::BQ),
-            H8 => new_board.castling_rights.remove(CastlingRights::BK),
+            A1 => new_board.castling_rights.remove(CastleType::WQ),
+            H1 => new_board.castling_rights.remove(CastleType::WK),
+            A8 => new_board.castling_rights.remove(CastleType::BQ),
+            H8 => new_board.castling_rights.remove(CastleType::BK),
             _ => {}
         }
 

--- a/simbelmyne/Cargo.toml
+++ b/simbelmyne/Cargo.toml
@@ -19,3 +19,4 @@ colored = "2.0.4"
 clap = { version = "4.4.7", features = ["derive"] }
 itertools = "0.11.0"
 rayon = "1.8.1"
+arrayvec = "0.7.4"

--- a/simbelmyne/src/cli/perft.rs
+++ b/simbelmyne/src/cli/perft.rs
@@ -42,9 +42,9 @@ pub fn perft<const BULK: bool>(board: Board, depth: usize) -> usize {
     }
 
     moves
-        .iter()
+        .into_iter()
         .map(|mv| {
-            let new_board = board.play_move(*mv);
+            let new_board = board.play_move(mv);
             let nodes = perft::<BULK>(new_board, depth - 1);
             nodes
         })

--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -30,7 +30,8 @@
 //! 5. Quiets: Play the quiet moves in sorted order, again doing a partial sort
 //! on every pass until we reach the end.
 
-use chess::movegen::move_array::MoveArray;
+use chess::movegen::legal_moves::MAX_MOVES;
+use chess::movegen::legal_moves::MoveList;
 use chess::movegen::moves::Move;
 use chess::piece::PieceType;
 use crate::search::params::MOVE_ORDERING;
@@ -69,7 +70,7 @@ pub struct MovePicker<'pos> {
     stage: Stage,
 
     /// The stored moves in the move picker
-    moves: MoveArray,
+    moves: MoveList,
 
     /// The index of the move up to which we have already yielded.
     index: usize,
@@ -84,7 +85,7 @@ pub struct MovePicker<'pos> {
     tt_move: Option<Move>,
 
     /// The scores associated with every move, using the same indexing
-    scores: [i32; MoveArray::SIZE],
+    scores: [i32; MAX_MOVES],
 
     /// The current board position
     position: &'pos Position,
@@ -102,11 +103,11 @@ pub struct MovePicker<'pos> {
 impl<'pos> MovePicker<'pos> {
     pub fn new(
         position: &'pos Position, 
-        moves: MoveArray,
+        moves: MoveList,
         tt_move: Option<Move>,
         killers: Killers,
     ) -> MovePicker<'pos> {
-        let scores = [0; MoveArray::SIZE];
+        let scores = [0; MAX_MOVES];
 
         // If the move list is empty, we're done here.
         let initial_stage = if moves.len() == 0 { 

--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -84,7 +84,7 @@ pub struct MovePicker<'pos> {
     tt_move: Option<Move>,
 
     /// The scores associated with every move, using the same indexing
-    scores: Vec<i32>,
+    scores: [i32; MoveArray::SIZE],
 
     /// The current board position
     position: &'pos Position,
@@ -106,10 +106,7 @@ impl<'pos> MovePicker<'pos> {
         tt_move: Option<Move>,
         killers: Killers,
     ) -> MovePicker<'pos> {
-        let mut scores = Vec::new();
-
-        // Start with a pre-allocated vector of scores
-        scores.resize_with(moves.len(), i32::default);
+        let scores = [0; MoveArray::SIZE];
 
         // If the move list is empty, we're done here.
         let initial_stage = if moves.len() == 0 { 

--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -30,6 +30,7 @@
 //! 5. Quiets: Play the quiet moves in sorted order, again doing a partial sort
 //! on every pass until we reach the end.
 
+use chess::movegen::move_array::MoveArray;
 use chess::movegen::moves::Move;
 use chess::piece::PieceType;
 use crate::search::params::MOVE_ORDERING;
@@ -68,7 +69,7 @@ pub struct MovePicker<'pos> {
     stage: Stage,
 
     /// The stored moves in the move picker
-    moves: Vec<Move>,
+    moves: MoveArray,
 
     /// The index of the move up to which we have already yielded.
     index: usize,
@@ -101,7 +102,7 @@ pub struct MovePicker<'pos> {
 impl<'pos> MovePicker<'pos> {
     pub fn new(
         position: &'pos Position, 
-        moves: Vec<Move>, 
+        moves: MoveArray,
         tt_move: Option<Move>,
         killers: Killers,
     ) -> MovePicker<'pos> {

--- a/simbelmyne/src/position.rs
+++ b/simbelmyne/src/position.rs
@@ -4,7 +4,8 @@
 //! additional game data, that the chess backend doesn't have any knowledge of.
 //! These are things such as evaluation, Zobrist hashing, and game history.
 
-use chess::{board::Board, movegen::{moves::{Move, BareMove}, castling::CastleType}, array_vec::ArrayVec};
+use arrayvec::ArrayVec;
+use chess::{board::Board, movegen::{moves::{Move, BareMove}, castling::CastleType}};
 use crate::{evaluate::Eval, zobrist::ZHash};
 
 // We don't ever expect to exceed 100 entries, because that would be a draw.
@@ -282,8 +283,8 @@ mod tests {
             let board = fen.parse().unwrap();
             let position = Position::new(board);
 
-            let all_match = board.legal_moves::<QUIETS>().iter()
-                .map(|&mv| position.play_move(mv))
+            let all_match = board.legal_moves::<QUIETS>().into_iter()
+                .map(|mv| position.play_move(mv))
                 .all(|new_pos| new_pos.hash == new_pos.board.hash());
 
             if all_match {

--- a/simbelmyne/src/position.rs
+++ b/simbelmyne/src/position.rs
@@ -7,6 +7,7 @@
 use chess::{board::Board, movegen::{moves::{Move, BareMove}, castling::CastleType}, array_vec::ArrayVec};
 use crate::{evaluate::Eval, zobrist::ZHash};
 
+const HIST_SIZE: usize = 100;
 
 /// Wrapper around a `Board` that stores additional metadata that is not tied to
 /// the board itself, but rather to the search and evaluation algorithms.
@@ -23,7 +24,7 @@ pub struct Position {
 
     /// A history of Zobrist hashes going back to the last half-move counter
     /// reset.
-    pub history: ArrayVec<ZHash, 100>
+    pub history: ArrayVec<ZHash, HIST_SIZE>
 }
 
 impl Position {

--- a/simbelmyne/src/position.rs
+++ b/simbelmyne/src/position.rs
@@ -4,7 +4,7 @@
 //! additional game data, that the chess backend doesn't have any knowledge of.
 //! These are things such as evaluation, Zobrist hashing, and game history.
 
-use chess::{board::Board, movegen::{moves::{Move, BareMove}, castling::CastleType}};
+use chess::{board::Board, movegen::{moves::{Move, BareMove}, castling::CastleType}, array_vec::ArrayVec};
 use crate::{evaluate::Eval, zobrist::ZHash};
 
 
@@ -23,7 +23,7 @@ pub struct Position {
 
     /// A history of Zobrist hashes going back to the last half-move counter
     /// reset.
-    pub history: Vec<ZHash>,
+    pub history: ArrayVec<ZHash, 100>
 }
 
 impl Position {
@@ -35,7 +35,7 @@ impl Position {
             hash: ZHash::from(board),
             // We don't ever expect to exceed 100 entries, because that would be 
             // a draw.
-            history: Vec::with_capacity(100),
+            history: ArrayVec::new(),
         }
     }
 

--- a/simbelmyne/src/position.rs
+++ b/simbelmyne/src/position.rs
@@ -7,6 +7,7 @@
 use chess::{board::Board, movegen::{moves::{Move, BareMove}, castling::CastleType}, array_vec::ArrayVec};
 use crate::{evaluate::Eval, zobrist::ZHash};
 
+// We don't ever expect to exceed 100 entries, because that would be a draw.
 const HIST_SIZE: usize = 100;
 
 /// Wrapper around a `Board` that stores additional metadata that is not tied to
@@ -34,8 +35,6 @@ impl Position {
             board, 
             score: Eval::new(&board),
             hash: ZHash::from(board),
-            // We don't ever expect to exceed 100 entries, because that would be 
-            // a draw.
             history: ArrayVec::new(),
         }
     }

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -6,6 +6,7 @@ use crate::transpositions::TTable;
 use crate::move_picker::MovePicker;
 use crate::position::Position;
 use crate::evaluate::Score;
+use chess::movegen::legal_moves::MoveList;
 use chess::movegen::moves::Move;
 
 use super::Search;
@@ -286,7 +287,7 @@ impl Position {
         ////////////////////////////////////////////////////////////////////////
 
         let mut move_count = 0;
-        let mut quiets_tried = Vec::with_capacity(50);
+        let mut quiets_tried = MoveList::new();
 
         while let Some(mv) = legal_moves.next(&search.history_table) {
             if !search.tc.should_continue() {


### PR DESCRIPTION
Remove any remaining allocations from the (hot) code paths, and replace them with `ArrayVec`s, or simply iterators when they never need to be collected.

- `Board::legal_moves`
- `position.history`
- `CastlingRights::get_all` and `CastlingRights.get_available`

Was definitely expecting more of a speedup, but okay... 🤷 

```
Score of Simbelmyne vs Simbelmyne main: 547 - 479 - 686 [0.520]
...      Simbelmyne playing White: 350 - 181 - 325  [0.599] 856
...      Simbelmyne playing Black: 197 - 298 - 361  [0.441] 856
...      White vs Black: 648 - 378 - 686  [0.579] 1712
Elo difference: 13.8 +/- 12.7, LOS: 98.3 %, DrawRatio: 40.1 %
1718 of 2500 games finished.
```