### PR TITLE
Use TT in Qsearch (+23 +- 12)

### DIFF
--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -139,7 +139,7 @@ impl<'pos> MovePicker<'pos> {
     /// Return the number of tacticals in the set of moves
     pub fn count_tacticals(&self) -> usize {
         self.moves.iter()
-            .filter(|mv| mv.is_capture() || mv.is_castle())
+            .filter(|mv| mv.is_tactical())
             .count()
     }
 

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -69,7 +69,7 @@ impl Position {
 
         if depth == 0 || ply >= MAX_DEPTH {
             if QUIESCENCE_SEARCH {
-                return self.quiescence_search(ply, alpha, beta, pv, search);
+                return self.quiescence_search(ply, alpha, beta, tt, pv, search);
             } else {
                 search.tc.add_node();
                 return self.score.total(self.board.current);
@@ -246,7 +246,6 @@ impl Position {
             tt_move,
             search.killers[ply],
         );
-
 
         // Checkmate?
         if legal_moves.len() == 0 && in_check {


### PR DESCRIPTION
Took forever to figure out how to make it gain.

Feels like the big issue was that I wasn't checking for checkmate in any way.
Viri and Carp seem to use a _"pseudo-mate"_ score, where they assign a score of `-5000` if we're in check but there's no available captures. Recall: I removed the `in_check` test because I figured we can't test for mate when we don't consider all the moves. This pseudo-mate score is one way around it: it's probably a really bad position to be in, but we're not sure if it's mate or not.

Cheers is a bit more exact (and is the approach I went with here): if we're in check and there are no tacticals available, fetch _all_ the legal moves and see whether it's checkmate.

```
Score of Simbelmyne vs Simbelmyne main: 620 - 502 - 681 [0.533]
...      Simbelmyne playing White: 378 - 189 - 335  [0.605] 902
...      Simbelmyne playing Black: 242 - 313 - 346  [0.461] 901
...      White vs Black: 691 - 431 - 681  [0.572] 1803
Elo difference: 22.8 +/- 12.6, LOS: 100.0 %, DrawRatio: 37.8 %
1815 of 2500 games finished.
```