### PR TITLE
Search/fail soft (+20)

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -2,13 +2,14 @@
 
 ## Extensions
 - [ ] Singular move extension: Extend depth by 1 if there is only one legal move
-      (basically a free +1 to depth, because the branching factor is 1)
+      (basically a free +1 to depth, because the branching factor is 1) (failed)
+- [ ] Actual singular extensions
 
 ## Reductions
 - [✓] Internal Iterative Reduction (when no TT move is found)
 
 ## Pruning
-- [ ] Delta pruning
+- [✓] Delta pruning
 - [✓] More sophisticated null-move pruning, add Zugzwang check
 - [ ] SEE pruning
 - [ ] Razoring
@@ -20,8 +21,10 @@
 - [ ] Capture history?
 
 ## Evaluation
-- [ ] King safety terms
-- [ ] Connected rooks
+- [ ] King safety terms (failed)
+- [ ] Connected rooks (failed)
+- [ ] Pinned pieces (failed)
+- [ ] Connected pawns
 - [✓] Bishop pairs
 - [✓] Mobility
 - [✓] Parameter tuning
@@ -30,3 +33,6 @@
 ## Misc
 - [✓] Tighten integer types and table entry sizes to the absolute minimum
 - [ ] Store checkers bitboards on board
+- [ ] Store checkers bitboards on board (or attacked pieces?)
+- [ ] Report mate score
+- [ ] Mate in N mode

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -215,7 +215,7 @@ impl Position {
                 );
 
             if score >= beta {
-                return beta;
+                return score;
             }
         }
 
@@ -435,14 +435,6 @@ impl Position {
         // is an upper/lower bound, or exact.
         //
         ////////////////////////////////////////////////////////////////////////
-        
-        // Fail-hard semantics: the score we return is clamped to the
-        // `alpha`-`beta` window.
-        let score = match node_type {
-            NodeType::Upper => alpha,
-            NodeType::Exact => best_score,
-            NodeType::Lower => beta,
-        };
 
         // If we had a cutoff, update the Killers and History
         if node_type == NodeType::Lower && best_move.is_quiet() {
@@ -466,7 +458,7 @@ impl Position {
             tt.insert(TTEntry::new(
                 self.hash,
                 best_move,
-                score,
+                best_score,
                 eval,
                 depth,
                 node_type,
@@ -475,7 +467,7 @@ impl Position {
             ));
         }
 
-        score
+        best_score
     }
 }
 

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -166,18 +166,23 @@ impl Position {
         //
         // If we're close to the max depth of the search, and the static 
         // evaluation board is some margin above beta, assume it's highly 
-        // unlikely for the search _not_ to end in a cutoff, and just return
-        // beta instead.
+        // unlikely for the search _not_ to end in a cutoff. Instead, just 
+        // return a compromise value between the current eval and beta.
+        //
+        // TODO: Other options to try here are: 
+        // - return eval
+        // - return the "Worst case scenario" score (eval - futility)
         //
         ////////////////////////////////////////////////////////////////////////
 
-        if depth <= search.search_params.rfp_threshold 
-            && eval >= beta.saturating_add(search.search_params.rfp_margin * depth as Score)
+        let futility = search.search_params.rfp_margin * depth as Score;
+
+        if !PV 
             && !in_root
             && !in_check
-            && !PV
-        {
-            return beta;
+            && depth <= search.search_params.rfp_threshold
+            && eval - futility >= beta {
+            return (eval + beta) / 2;
         }
 
         ////////////////////////////////////////////////////////////////////////

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -74,7 +74,7 @@ impl Position {
         }
 
         if eval >= beta {
-            return beta
+            return eval;
         }
 
         if alpha < eval {
@@ -207,20 +207,12 @@ impl Position {
         //
         ////////////////////////////////////////////////////////////////////////
 
-        // Fail-hard semantics: the score we return is clamped to the
-        // `alpha`-`beta` window.
-        let score = match node_type {
-            NodeType::Upper => alpha,
-            NodeType::Exact => best_score,
-            NodeType::Lower => beta,
-        };
-
         // Store in the TT
         if USE_TT {
             tt.insert(TTEntry::new(
                 self.hash,
                 best_move,
-                score,
+                best_score,
                 eval,
                 0,
                 node_type,
@@ -229,6 +221,6 @@ impl Position {
             ));
         }
 
-        score
+        best_score
     }
 }


### PR DESCRIPTION
```
Score of Simbelmyne vs Simbelmyne main: 671 - 553 - 822 [0.529]
...      Simbelmyne playing White: 364 - 235 - 424  [0.563] 1023
...      Simbelmyne playing Black: 307 - 318 - 398  [0.495] 1023
...      White vs Black: 682 - 542 - 822  [0.534] 2046
Elo difference: 20.1 +/- 11.6, LOS: 100.0 %, DrawRatio: 40.2 %
2046 of 2500 games finished.
```