### PR TITLE
Reduce good captures less (+13.6)

### DIFF
--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -52,8 +52,8 @@ const PIECE_VALS: [i32; PieceType::COUNT] =
 const KILLER_BONUS: i32 = 10000;
 
 /// The stages of move ordering
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
-enum Stage {
+#[derive(Debug, PartialEq, Eq, Copy, Clone, PartialOrd)]
+pub enum Stage {
     TTMove,
     ScoreTacticals,
     GoodTacticals,
@@ -129,6 +129,11 @@ impl<'pos> MovePicker<'pos> {
             killers,
             only_good_tacticals: false,
         }
+    }
+
+    /// Return the stage of movegen
+    pub fn stage(&self) -> Stage {
+        self.stage
     }
 
     /// Return the number of moves stored in the move picker

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -1,4 +1,5 @@
 use crate::evaluate::is_mate_score;
+use crate::move_picker::Stage;
 use crate::transpositions::NodeType;
 use crate::transpositions::TTEntry;
 use crate::search_tables::PVTable;
@@ -361,6 +362,9 @@ impl Position {
                     reduction += !PV as usize;
 
                     reduction += mv.is_quiet() as usize;
+
+                    // Reduce good tacticals less
+                    reduction -= (legal_moves.stage() < Stage::ScoreQuiets) as usize;
 
                     reduction = reduction.clamp(0, depth - 2);
                 }

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -67,8 +67,6 @@ impl Default for SearchParams {
             // Late move reductions
             lmr_min_depth: LMR_MIN_DEPTH,
             lmr_threshold: LMR_THRESHOLD,
-            lmr_max_moves: LMR_MAX_MOVES,
-            lmr_table: LMR_TABLE,
 
             delta_pruning_margin: DELTA_PRUNING_MARGIN,
 


### PR DESCRIPTION
```
Score of Simbelmyne vs Simbelmyne main: 754 - 656 - 1090 [0.520]
...      Simbelmyne playing White: 454 - 269 - 527  [0.574] 1250
...      Simbelmyne playing Black: 300 - 387 - 563  [0.465] 1250
...      White vs Black: 841 - 569 - 1090  [0.554] 2500
Elo difference: 13.6 +/- 10.2, LOS: 99.5 %, DrawRatio: 43.6 %
```