### PR TITLE
Fix pv reporting

### DIFF
--- a/simbelmyne/src/evaluate/mod.rs
+++ b/simbelmyne/src/evaluate/mod.rs
@@ -582,8 +582,8 @@ impl Sum for S {
 ////////////////////////////////////////////////////////////////////////////////
 
 pub trait ScoreExt {
-    const MIN: Self;
-    const MAX: Self;
+    const MINUS_INF: Self;
+    const PLUS_INF: Self;
     const DRAW: Self;
     const MATE: Self;
 
@@ -603,8 +603,8 @@ pub trait ScoreExt {
 }
 
 impl ScoreExt for Score {
-    const MIN: Self = Self::MIN + 1;
-    const MAX: Self = Self::MAX;
+    const MINUS_INF: Self = Self::MIN + 1;
+    const PLUS_INF: Self = Self::MAX;
     const DRAW: Self = 0;
     const MATE: Self = 20_000;
 

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -99,9 +99,10 @@ impl Position {
     pub fn search<const DEBUG: bool>(&self, tt: &mut TTable, history: &mut HistoryTable, tc: TimeController, search_params: &SearchParams) -> SearchReport {
         let mut depth = 1;
         let mut latest_report = SearchReport::default();
+        let mut pv = PVTable::new();
 
         while depth <= MAX_DEPTH && tc.should_start_search(depth) {
-            let mut pv = PVTable::new();
+            pv.clear();
             let mut search = Search::new(depth, history, tc.clone(), search_params);
 
             let score = self.aspiration_search(

--- a/simbelmyne/src/search/aspiration.rs
+++ b/simbelmyne/src/search/aspiration.rs
@@ -52,7 +52,7 @@ impl Position {
             // IF we fail low or high, grow the bounds upward/downward
             if score <= alpha {
                 alpha -= width;
-            } else if score > beta {
+            } else if score >= beta {
                 beta += width;
             } else {
                 return score;

--- a/simbelmyne/src/search/aspiration.rs
+++ b/simbelmyne/src/search/aspiration.rs
@@ -14,7 +14,7 @@
 //! The hope, as always in these things, is that the score is stable enough that
 //! re-searches are minimal, and the time we save in the best-case scenario
 //! more than compensates for the odd re-search.
-use crate::{position::Position, evaluate::Score, transpositions::TTable, search_tables::PVTable};
+use crate::{position::Position, evaluate::Score, evaluate::ScoreExt, transpositions::TTable, search_tables::PVTable};
 
 use super::Search;
 
@@ -28,13 +28,13 @@ impl Position {
         pv: &mut PVTable,
         search: &mut Search,
     ) -> Score {
-        let mut alpha = Score::MIN;
-        let mut beta = Score::MAX;
+        let mut alpha = Score::MINUS_INF;
+        let mut beta = Score::PLUS_INF;
         let mut width = search.search_params.aspiration_base_window;
 
         if depth >= search.search_params.aspiration_min_depth {
-            alpha = Score::max(Score::MIN, guess - width);
-            beta = Score::min(Score::MAX, guess + width);
+            alpha = Score::max(Score::MINUS_INF, guess - width);
+            beta = Score::min(Score::PLUS_INF, guess + width);
         }
 
         loop {
@@ -64,12 +64,12 @@ impl Position {
             // If the window exceeds the max width, give up and open the window 
             // up completely.
             if width > search.search_params.aspiration_max_window {
-                alpha = Score::MIN;
-                beta = Score::MAX;
+                alpha = Score::MINUS_INF;
+                beta = Score::PLUS_INF;
             }
 
             if search.aborted {
-                return Score::MIN;
+                return Score::MINUS_INF;
             }
         }
     }

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -93,13 +93,6 @@ impl Position {
         let mut alpha = alpha;
         let mut local_pv = PVTable::new();
 
-        // Rule-based draw? 
-        // Don't return early when in the root node, because we won't have a PV 
-        // move to play.
-        if !in_root && (self.board.is_rule_draw() || self.is_repetition()) {
-            return Score::DRAW;
-        }
-
         // Do all the static evaluations first
         // That is, Check whether we can/should assign a score to this node
         // without recursing any deeper.
@@ -107,12 +100,8 @@ impl Position {
         // Rule-based draw? 
         // Don't return early when in the root node, because we won't have a PV 
         // move to play.
-        if (self.board.is_rule_draw() || self.is_repetition()) && !in_root {
+        if !in_root && (self.board.is_rule_draw() || self.is_repetition()) {
             return Score::DRAW;
-        }
-
-        if ply >= MAX_DEPTH {
-            return self.score.total(self.board.current);
         }
 
         ////////////////////////////////////////////////////////////////////////
@@ -332,18 +321,18 @@ impl Position {
 
             // PV Move
             if move_count == 0 {
-            score = -self
-                .play_move(mv)
-                .negamax::<true>(
-                    ply + 1, 
-                    depth - 1, 
-                    -beta, 
-                    -alpha,
-                    tt, 
-                    &mut local_pv, 
-                    search, 
-                    false
-                );
+                score = -self
+                    .play_move(mv)
+                    .negamax::<true>(
+                        ply + 1, 
+                        depth - 1, 
+                        -beta, 
+                        -alpha,
+                        tt, 
+                        &mut local_pv, 
+                        search, 
+                        false
+                    );
 
             // Search other moves with null-window, and open up window if a move
             // increases alpha

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -118,7 +118,7 @@ impl Position {
         let tt_entry = tt.probe(self.hash);
         let tt_move = tt_entry.map(|entry| entry.get_move());
 
-        if !in_root && tt_entry.is_some() {
+        if !PV && !in_root && tt_entry.is_some() {
             let tt_entry = tt_entry.unwrap();
 
             // Can we use the stored score?

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -39,7 +39,7 @@ impl Position {
     ) -> Score {
         if search.aborted {
             pv.clear();
-            return Score::MIN;
+            return Score::MINUS_INF;
         }
 
         let in_root = ply == 0;
@@ -88,7 +88,7 @@ impl Position {
         search.tc.add_node();
 
         let mut best_move = Move::NULL;
-        let mut best_score = Score::MIN;
+        let mut best_score = Score::MINUS_INF;
         let mut node_type = NodeType::Upper;
         let mut alpha = alpha;
         let mut local_pv = PVTable::new();
@@ -297,7 +297,7 @@ impl Position {
         while let Some(mv) = legal_moves.next(&search.history_table) {
             if !search.tc.should_continue() {
                 search.aborted = true;
-                return Score::MIN;
+                return Score::MINUS_INF;
             }
 
             ////////////////////////////////////////////////////////////////////
@@ -431,7 +431,7 @@ impl Position {
             }
 
             if search.aborted {
-                return Score::MIN;
+                return Score::MINUS_INF;
             }
 
             move_count += 1;

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -37,7 +37,7 @@ impl Position {
     ) -> Score {
         if !search.tc.should_continue() {
             search.aborted = true;
-            return Score::MIN;
+            return Score::MINUS_INF;
         }
 
         search.tc.add_node();
@@ -194,7 +194,7 @@ impl Position {
 
             if search.aborted {
                 pv.clear();
-                return Score::MIN;
+                return Score::MINUS_INF;
             }
         }
 

--- a/simbelmyne/src/transpositions.rs
+++ b/simbelmyne/src/transpositions.rs
@@ -167,11 +167,11 @@ impl TTEntry {
             NodeType::Exact => Some(absolute_score),
 
             NodeType::Upper if absolute_score <= alpha => {
-                Some(alpha)
+                Some(absolute_score)
             },
 
             NodeType::Lower if absolute_score >= beta => {
-                Some(beta)
+                Some(absolute_score)
             },
 
             _ => None

--- a/uci/src/engine.rs
+++ b/uci/src/engine.rs
@@ -55,6 +55,9 @@ impl Display for UciEngineMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use UciEngineMessage::*;
 
+        // TODO: Make this a bunch fancier when we know we're printing to a 
+        // terminal
+        // How would we go about doing that?
         match self {
             Id(id_option) => write!(f, "id {id_option}"),
             UciOk => write!(f, "uciok"),


### PR DESCRIPTION
Bunch of cleanups. Avoids a lot of the PV reporting issues (illegal states, shortened PVs, etc).

Mostly testing for non-regression, but probably a bit stronger on account of the fail-soft scores we're returning from the TT.

```
Score of Simbelmyne vs Simbelmyne v1.5.0: 413 - 372 - 623 [0.515]
...      Simbelmyne playing White: 239 - 155 - 310  [0.560] 704
...      Simbelmyne playing Black: 174 - 217 - 313  [0.469] 704
...      White vs Black: 456 - 329 - 623  [0.545] 1408
Elo difference: 10.1 +/- 13.5, LOS: 92.8 %, DrawRatio: 44.2 %
SPRT: llr 0 (0.0%), lbound -inf, ubound inf
1408 of 2500 games finished.
```