### PR TITLE
Eval/refactor incremental context

### DIFF
--- a/chess/src/bitboard.rs
+++ b/chess/src/bitboard.rs
@@ -6,7 +6,7 @@
 //! instruction.
 
 use std::fmt::Display;
-use crate::{constants::FILES, piece::Color, square::Square};
+use crate::{constants::FILES, square::Square};
 use std::ops::{
     BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Deref, Not, Shl,
     ShlAssign, Shr, ShrAssign,
@@ -49,6 +49,7 @@ impl Bitboard {
     /// Get the square corresponding to the first (leading) bit of this 
     /// bitboard.
     /// Panics when passed an empty bitboard!
+    #[inline(always)]
     pub fn first(self) -> Square {
         let msb = 63 - self.leading_zeros(); // 0..=63
         (msb as usize).into()
@@ -57,34 +58,40 @@ impl Bitboard {
     /// Get the square corresponding to the last (trailing) bit of this 
     /// bitboard.
     /// Panics when passed an empty bitboard!
+    #[inline(always)]
     pub fn last(self) -> Square {
         let lsb = self.trailing_zeros(); // 0..=63
         (lsb as usize).into()
     }
 
     /// Shift a bitboard left by one file
+    #[inline(always)]
     pub fn left(self) -> Self {
         self >> 1 & !FILES[7]
     }
 
     /// Shift a bitboard right by one file
+    #[inline(always)]
     pub fn right(self) -> Self {
         self << 1  & !FILES[0]
     }
 
     /// Shift a bitboard up by one rank
+    #[inline(always)]
     pub fn up(self) -> Self {
         self << 8
     }
 
     /// Shift a bitboard down by one rank
+    #[inline(always)]
     pub fn down(self) -> Self {
         self >> 8
     }
 
     /// Shift a bitboard one rank forward, relative to the requested color
-    pub fn forward(self, us: Color) -> Self {
-        if us.is_white() {
+    #[inline(always)]
+    pub fn forward<const WHITE: bool>(self) -> Self {
+        if WHITE {
             self.up()
         } else {
             self.down()
@@ -92,27 +99,48 @@ impl Bitboard {
     }
 
     /// Shift a bitboard one rank backward, relative to the requested color
-    pub fn backward(self, us: Color) -> Self {
-        if us.is_white() {
+    #[inline(always)]
+    pub fn backward<const WHITE: bool>(self) -> Self {
+        if WHITE {
             self.down()
         } else {
             self.up()
         }
     }
 
-    pub fn forward_left(self, us: Color) -> Self {
-        if us.is_white() {
+    #[inline(always)]
+    pub fn forward_left<const WHITE: bool>(self) -> Self {
+        if WHITE {
             self << 7 & !FILES[7]
         } else {
             self >> 9 & !FILES[7]
         }
     }
 
-    pub fn forward_right(self, us: Color) -> Self {
-        if us.is_white() {
+    #[inline(always)]
+    pub fn forward_right<const WHITE: bool>(self) -> Self {
+        if WHITE {
             self << 9 & !FILES[0]
         } else {
             self >> 7 & !FILES[0]
+        }
+    }
+
+    #[inline(always)]
+    pub fn backward_left<const WHITE: bool>(self) -> Self {
+        if WHITE {
+            self >> 9 & !FILES[7]
+        } else {
+            self << 7 & !FILES[7]
+        }
+    }
+
+    #[inline(always)]
+    pub fn backward_right<const WHITE: bool>(self) -> Self {
+        if WHITE {
+            self >> 7 & !FILES[0]
+        } else {
+            self << 9 & !FILES[0]
         }
     }
 }

--- a/simbelmyne/src/evaluate/mod.rs
+++ b/simbelmyne/src/evaluate/mod.rs
@@ -26,6 +26,7 @@
 mod lookups;
 pub mod params;
 pub mod tuner;
+pub mod pretty_print;
 mod piece_square_tables;
 
 use std::iter::Sum;
@@ -71,7 +72,6 @@ use crate::evaluate::params::PAWN_STORM_BONUS;
 use crate::evaluate::params::KING_ZONE_ATTACKS;
 use crate::evaluate::params::PHALANX_PAWN_BONUS;
 
-use colored::Colorize;
 
 use self::params::PASSERS_ENEMY_KING_PENALTY;
 use self::params::PASSERS_FRIENDLY_KING_BONUS;
@@ -879,142 +879,4 @@ impl ScoreExt for Score {
             self
         }
     }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-//
-// Print evaluation
-//
-////////////////////////////////////////////////////////////////////////////////
-
-fn blank_line(rank: usize) -> String {
-        let mut line: Vec<String> = Vec::new();
-        line.push("  ║".to_string());
-    if rank % 2 == 0 {
-        line.push("       ".on_white().to_string());
-        line.push("       ".on_black().to_string());
-        line.push("       ".on_white().to_string());
-        line.push("       ".on_black().to_string());
-        line.push("       ".on_white().to_string());
-        line.push("       ".on_black().to_string());
-        line.push("       ".on_white().to_string());
-        line.push("       ".on_black().to_string());
-    } else {
-        line.push("       ".on_black().to_string());
-        line.push("       ".on_white().to_string());
-        line.push("       ".on_black().to_string());
-        line.push("       ".on_white().to_string());
-        line.push("       ".on_black().to_string());
-        line.push("       ".on_white().to_string());
-        line.push("       ".on_black().to_string());
-        line.push("       ".on_white().to_string());
-    }
-
-    line.push("║ ".to_string());
-    line.join("")
-}
-
-pub fn print_eval(board: &Board) -> String {
-    let eval = Eval::new(board);
-
-    let mut lines: Vec<String> = vec![];
-    lines.push("      a      b      c      d      e      f      g      h    ".to_string());
-    lines.push("  ╔════════════════════════════════════════════════════════╗".to_string());
-
-    for (rank, squares) in Square::RANKS.into_iter().enumerate() {
-        lines.push(blank_line(rank));
-
-        // Piece character
-        let mut line: Vec<String> = vec![];
-        line.push((8 - rank).to_string());
-        line.push(" ║".to_string());
-        for (file, sq) in squares.into_iter().enumerate() {
-            let bg = if (rank + file) % 2 == 0 { "white" } else { "black" };
-            let fg = if (rank + file) % 2 == 0 { "black" } else { "white" };
-
-            let square = match board.get_at(sq) {
-                Some(piece) => format!("   {}   ", piece).color(fg).on_color(bg),
-                None => "       ".to_string().on_color(bg),
-            };
-
-            line.push(square.to_string());
-        }
-        line.push("║ ".to_string());
-        line.push((8 - rank).to_string());
-        lines.push(line.join(""));
-
-        lines.push(blank_line(rank));
-
-        // Piece score
-        let mut line: Vec<String> = vec![];
-        line.push("  ║".to_string());
-        for (file, sq) in squares.into_iter().enumerate() {
-            let bg = if (rank + file) % 2 == 0 { "white" } else { "black" };
-            let fg = if (rank + file) % 2 == 0 { "black" } else { "white" };
-            let score = if let Some(piece) = board.get_at(sq) {
-                // Get score for piece
-                let score = board.material(piece) + board.psqt(piece, sq);
-                let pawn_score = score.lerp(eval.game_phase) as f32 / 100.0;
-
-                format!("{:.2}", pawn_score)
-            } else {
-                "".to_string()
-            };
-
-            line.push(format!("{:^7}", score.color(fg).on_color(bg)));
-            
-        }
-        line.push("║  ".to_string());
-        let line = line.join("");
-
-        lines.push(line);
-
-
-    }
-    lines.push("  ╚════════════════════════════════════════════════════════╝".to_string());
-    lines.push("      a      b      c      d      e      f      g      h    ".to_string());
-
-    lines.push("\n".to_string());
-    lines.push("Evaluation features:".blue().to_string());
-    lines.push("--------------------".blue().to_string());
-
-    let mut ctx = EvalContext::new(board);
-
-    let white_pawn_structure =  board.pawn_structure::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
-    let black_pawn_structure = -board.pawn_structure::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Pawn structure:", white_pawn_structure, black_pawn_structure));
-
-    let white_bishop_pair =  board.bishop_pair::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
-    let black_bishop_pair = -board.bishop_pair::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Bishop pair", white_bishop_pair, black_bishop_pair));
-
-    let white_rook_open_file =  board.rook_open_file::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
-    let black_rook_open_file = -board.rook_open_file::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Rook on open file:", white_rook_open_file, black_rook_open_file));
-
-    let white_pawn_shield =  board.pawn_shield::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
-    let black_pawn_shield = -board.pawn_shield::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Pawn shield:", white_pawn_shield, black_pawn_shield));
-
-    let white_pawn_storm =  board.pawn_storm::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
-    let black_pawn_storm = -board.pawn_storm::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Pawn storm:", white_pawn_storm, black_pawn_storm));
-
-    let white_mobility =  board.mobility::<WHITE>(&mut ctx).lerp(eval.game_phase) as f32 / 100.0;
-    let black_mobility = -board.mobility::<BLACK>(&mut ctx).lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Mobility:", white_mobility, black_mobility));
-
-    let white_virtual_mobility =  board.virtual_mobility::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
-    let black_virtual_mobility = -board.virtual_mobility::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Virtual mobility:", white_virtual_mobility, black_virtual_mobility));
-
-    let white_king_zone =  board.king_zone::<WHITE>(&mut ctx).lerp(eval.game_phase) as f32 / 100.0;
-    let black_king_zone = -board.king_zone::<BLACK>(&mut ctx).lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "King zone:", white_king_zone, black_king_zone));
-
-    lines.push("".to_string());
-
-    lines.push(format!("Total: {}", eval.total(&board)));
-
-    lines.join("\n")
 }

--- a/simbelmyne/src/evaluate/mod.rs
+++ b/simbelmyne/src/evaluate/mod.rs
@@ -516,7 +516,9 @@ impl Evaluate for Board {
 
     fn queen_semiopen_file<const WHITE: bool>(&self, pawn_structure: &PawnStructure) -> S {
         let us = if WHITE { White } else { Black };
-        let queens_on_semi = self.queens(us) & pawn_structure.semi_open_files(us);
+        let queens_on_semi = self.queens(us) 
+            & pawn_structure.semi_open_files(us)
+            & !pawn_structure.open_files();
         QUEEN_SEMIOPEN_FILE_BONUS * queens_on_semi.count() as i32
     }
 

--- a/simbelmyne/src/evaluate/mod.rs
+++ b/simbelmyne/src/evaluate/mod.rs
@@ -26,6 +26,7 @@
 mod lookups;
 pub mod params;
 pub mod tuner;
+pub mod pawn_structure;
 pub mod pretty_print;
 mod piece_square_tables;
 
@@ -48,36 +49,28 @@ use chess::piece::PieceType;
 use chess::piece::Color;
 use chess::piece::Color::*;
 
-use crate::evaluate::lookups::FILES;
-use crate::evaluate::lookups::DOUBLED_PAWN_MASKS;
-use crate::evaluate::lookups::ISOLATED_PAWN_MASKS;
 use crate::evaluate::lookups::PASSED_PAWN_MASKS;
 use crate::evaluate::params::CONNECTED_ROOKS_BONUS;
 use crate::evaluate::params::QUEEN_OPEN_FILE_BONUS;
 use crate::evaluate::piece_square_tables::PIECE_SQUARE_TABLES;
 use crate::evaluate::params::BISHOP_MOBILITY_BONUS;
 use crate::evaluate::params::BISHOP_PAIR_BONUS;
-use crate::evaluate::params::DOUBLED_PAWN_PENALTY;
-use crate::evaluate::params::ISOLATED_PAWN_PENALTY;
 use crate::evaluate::params::KNIGHT_MOBILITY_BONUS;
-use crate::evaluate::params::PASSED_PAWN_TABLE;
 use crate::evaluate::params::QUEEN_MOBILITY_BONUS;
 use crate::evaluate::params::ROOK_MOBILITY_BONUS;
 use crate::evaluate::params::ROOK_OPEN_FILE_BONUS;
 use crate::evaluate::params::PIECE_VALUES;
 use crate::evaluate::params::PAWN_SHIELD_BONUS;
 use crate::evaluate::params::VIRTUAL_MOBILITY_PENALTY;
-use crate::evaluate::params::CONNECTED_PAWN_BONUS;
 use crate::evaluate::params::PAWN_STORM_BONUS;
 use crate::evaluate::params::KING_ZONE_ATTACKS;
-use crate::evaluate::params::PHALANX_PAWN_BONUS;
-
 
 use self::params::PASSERS_ENEMY_KING_PENALTY;
 use self::params::PASSERS_FRIENDLY_KING_BONUS;
 use self::params::MAJOR_ON_SEVENTH_BONUS;
 use self::params::QUEEN_SEMIOPEN_FILE_BONUS;
 use self::params::ROOK_SEMIOPEN_FILE_BONUS;
+use self::pawn_structure::PawnStructure;
 
 pub type Score = i32;
 
@@ -109,7 +102,7 @@ pub struct Eval {
     psqt: S,
 
     /// The total pawn structure score
-    pawn_structure: S,
+    pawn_structure: PawnStructure,
 
     /// A bonus score for having two bishops on the board
     bishop_pair: S,
@@ -177,7 +170,7 @@ impl Eval {
     pub fn total(&self, board: &Board) -> Score {
         let mut total = self.material
             + self.psqt
-            + self.pawn_structure
+            + self.pawn_structure.score()
             + self.bishop_pair
             + self.rook_open_file
             + self.rook_semiopen_file
@@ -190,10 +183,18 @@ impl Eval {
             + self.passers_enemy_king;
 
         let mut ctx = EvalContext::new(board);
-        total += board.connected_rooks::<WHITE>()   - board.connected_rooks::<BLACK>();
-        total += board.mobility::<WHITE>(&mut ctx)  - board.mobility::<BLACK>(&mut ctx);
-        total += board.virtual_mobility::<WHITE>()  - board.virtual_mobility::<BLACK>();
-        total += board.king_zone::<WHITE>(&mut ctx) - board.king_zone::<BLACK>(&mut ctx);
+
+        total += board.connected_rooks::<WHITE>()
+               - board.connected_rooks::<BLACK>()
+
+               + board.mobility::<WHITE>(&mut ctx, &self.pawn_structure)
+               - board.mobility::<BLACK>(&mut ctx, &self.pawn_structure)
+
+               + board.virtual_mobility::<WHITE>()
+               - board.virtual_mobility::<BLACK>()
+
+               + board.king_zone::<WHITE>(&mut ctx) 
+               - board.king_zone::<BLACK>(&mut ctx);
 
         let score = total.lerp(self.game_phase);
 
@@ -207,42 +208,7 @@ impl Eval {
         self.material += board.material(piece);
         self.psqt += board.psqt(piece, sq);
 
-        if piece.is_pawn() {
-            self.pawn_structure        = board.pawn_structure::<WHITE>()        - board.pawn_structure::<BLACK>();
-            self.pawn_shield           = board.pawn_shield::<WHITE>()           - board.pawn_shield::<BLACK>();
-            self.pawn_storm            = board.pawn_storm::<WHITE>()            - board.pawn_storm::<BLACK>();
-            self.rook_open_file        = board.rook_open_file::<WHITE>()        - board.rook_open_file::<BLACK>();
-            self.rook_semiopen_file    = board.rook_semiopen_file::<WHITE>()    - board.rook_semiopen_file::<BLACK>();
-            self.queen_open_file       = board.queen_open_file::<WHITE>()       - board.queen_open_file::<BLACK>();
-            self.queen_semiopen_file   = board.queen_semiopen_file::<WHITE>()   - board.queen_semiopen_file::<BLACK>();
-            self.major_on_seventh      = board.major_on_seventh::<WHITE>()      - board.major_on_seventh::<BLACK>();
-            self.passers_friendly_king = board.passers_friendly_king::<WHITE>() - board.passers_friendly_king::<BLACK>();
-            self.passers_enemy_king    = board.passers_enemy_king::<WHITE>()    - board.passers_enemy_king::<BLACK>();
-        }
-
-        if piece.is_bishop() {
-            self.bishop_pair    = board.bishop_pair::<WHITE>()       - board.bishop_pair::<BLACK>();
-        }
-
-        if piece.is_rook() {
-            self.rook_open_file     = board.rook_open_file::<WHITE>()      - board.rook_open_file::<BLACK>();
-            self.rook_semiopen_file = board.rook_semiopen_file::<WHITE>()  - board.rook_semiopen_file::<BLACK>();
-            self.major_on_seventh   = board.major_on_seventh::<WHITE>()    - board.major_on_seventh::<BLACK>();
-        }
-
-        if piece.is_queen() {
-            self.queen_open_file     = board.queen_open_file::<WHITE>()      - board.queen_open_file::<BLACK>();
-            self.queen_semiopen_file = board.queen_semiopen_file::<WHITE>()  - board.queen_semiopen_file::<BLACK>();
-            self.major_on_seventh    = board.major_on_seventh::<WHITE>()     - board.major_on_seventh::<BLACK>();
-        }
-
-        if piece.is_king() {
-            self.pawn_shield           = board.pawn_shield::<WHITE>()           - board.pawn_shield::<BLACK>();
-            self.pawn_storm            = board.pawn_storm::<WHITE>()            - board.pawn_storm::<BLACK>();
-            self.passers_friendly_king = board.passers_friendly_king::<WHITE>() - board.passers_friendly_king::<BLACK>();
-            self.passers_enemy_king    = board.passers_enemy_king::<WHITE>()    - board.passers_enemy_king::<BLACK>();
-            self.major_on_seventh      = board.major_on_seventh::<WHITE>()      - board.major_on_seventh::<BLACK>();
-        }
+        self.update_incremental_terms(piece, board)
     }
 
     /// Update the score by removing a piece from it
@@ -252,42 +218,7 @@ impl Eval {
         self.material -= board.material(piece);
         self.psqt -= board.psqt(piece, sq);
 
-        if piece.is_pawn() {
-            self.pawn_structure        = board.pawn_structure::<WHITE>()        - board.pawn_structure::<BLACK>();
-            self.pawn_shield           = board.pawn_shield::<WHITE>()           - board.pawn_shield::<BLACK>();
-            self.pawn_storm            = board.pawn_storm::<WHITE>()            - board.pawn_storm::<BLACK>();
-            self.rook_open_file        = board.rook_open_file::<WHITE>()        - board.rook_open_file::<BLACK>();
-            self.rook_semiopen_file    = board.rook_semiopen_file::<WHITE>()    - board.rook_semiopen_file::<BLACK>();
-            self.queen_open_file       = board.queen_open_file::<WHITE>()       - board.queen_open_file::<BLACK>();
-            self.queen_semiopen_file   = board.queen_semiopen_file::<WHITE>()   - board.queen_semiopen_file::<BLACK>();
-            self.major_on_seventh      = board.major_on_seventh::<WHITE>()      - board.major_on_seventh::<BLACK>();
-            self.passers_friendly_king = board.passers_friendly_king::<WHITE>() - board.passers_friendly_king::<BLACK>();
-            self.passers_enemy_king    = board.passers_enemy_king::<WHITE>()    - board.passers_enemy_king::<BLACK>();
-        }
-
-        if piece.is_bishop() {
-            self.bishop_pair    = board.bishop_pair::<WHITE>()       - board.bishop_pair::<BLACK>();
-        }
-
-        if piece.is_rook() {
-            self.rook_open_file     = board.rook_open_file::<WHITE>()      - board.rook_open_file::<BLACK>();
-            self.rook_semiopen_file = board.rook_semiopen_file::<WHITE>()  - board.rook_semiopen_file::<BLACK>();
-            self.major_on_seventh   = board.major_on_seventh::<WHITE>()    - board.major_on_seventh::<BLACK>();
-        }
-
-        if piece.is_queen() {
-            self.queen_open_file     = board.queen_open_file::<WHITE>()      - board.queen_open_file::<BLACK>();
-            self.queen_semiopen_file = board.queen_semiopen_file::<WHITE>()  - board.queen_semiopen_file::<BLACK>();
-            self.major_on_seventh    = board.major_on_seventh::<WHITE>()     - board.major_on_seventh::<BLACK>();
-        }
-
-        if piece.is_king() {
-            self.pawn_shield           = board.pawn_shield::<WHITE>()           - board.pawn_shield::<BLACK>();
-            self.pawn_storm            = board.pawn_storm::<WHITE>()            - board.pawn_storm::<BLACK>();
-            self.passers_friendly_king = board.passers_friendly_king::<WHITE>() - board.passers_friendly_king::<BLACK>();
-            self.passers_enemy_king    = board.passers_enemy_king::<WHITE>()    - board.passers_enemy_king::<BLACK>();
-            self.major_on_seventh      = board.major_on_seventh::<WHITE>()      - board.major_on_seventh::<BLACK>();
-        }
+        self.update_incremental_terms(piece, board)
     }
 
     /// Update the score by moving a piece from one square to another
@@ -295,40 +226,86 @@ impl Eval {
         self.psqt -= board.psqt(piece, from);
         self.psqt += board.psqt(piece, to);
 
+        self.update_incremental_terms(piece, board)
+    }
+
+    fn update_incremental_terms(&mut self, piece: Piece, board: &Board) {
         if piece.is_pawn() {
-            self.pawn_structure        = board.pawn_structure::<WHITE>()        - board.pawn_structure::<BLACK>();
-            self.pawn_shield           = board.pawn_shield::<WHITE>()           - board.pawn_shield::<BLACK>();
-            self.pawn_storm            = board.pawn_storm::<WHITE>()            - board.pawn_storm::<BLACK>();
-            self.rook_open_file        = board.rook_open_file::<WHITE>()        - board.rook_open_file::<BLACK>();
-            self.rook_semiopen_file    = board.rook_semiopen_file::<WHITE>()    - board.rook_semiopen_file::<BLACK>();
-            self.queen_open_file       = board.queen_open_file::<WHITE>()       - board.queen_open_file::<BLACK>();
-            self.queen_semiopen_file   = board.queen_semiopen_file::<WHITE>()   - board.queen_semiopen_file::<BLACK>();
-            self.major_on_seventh      = board.major_on_seventh::<WHITE>()      - board.major_on_seventh::<BLACK>();
-            self.passers_friendly_king = board.passers_friendly_king::<WHITE>() - board.passers_friendly_king::<BLACK>();
-            self.passers_enemy_king    = board.passers_enemy_king::<WHITE>()    - board.passers_enemy_king::<BLACK>();
+            self.pawn_structure = PawnStructure::new(board);
+
+            self.pawn_shield = board.pawn_shield::<WHITE>() 
+                - board.pawn_shield::<BLACK>();
+
+            self.pawn_storm = board.pawn_storm::<WHITE>()
+                - board.pawn_storm::<BLACK>();
+
+            self.rook_open_file = board.rook_open_file::<WHITE>(&self.pawn_structure) 
+                - board.rook_open_file::<BLACK>(&self.pawn_structure);
+
+            self.rook_semiopen_file = board.rook_semiopen_file::<WHITE>(&self.pawn_structure)
+                - board.rook_semiopen_file::<BLACK>(&self.pawn_structure);
+
+            self.queen_open_file = board.queen_open_file::<WHITE>(&self.pawn_structure) 
+                - board.queen_open_file::<BLACK>(&self.pawn_structure);
+
+            self.queen_semiopen_file = board.queen_semiopen_file::<WHITE>(&self.pawn_structure)
+                - board.queen_semiopen_file::<BLACK>(&self.pawn_structure);
+
+            self.major_on_seventh = board.major_on_seventh::<WHITE>()
+                - board.major_on_seventh::<BLACK>();
+
+            self.passers_friendly_king = board.passers_friendly_king::<WHITE>(&self.pawn_structure)
+                - board.passers_friendly_king::<BLACK>(&self.pawn_structure);
+
+            self.passers_enemy_king = board.passers_enemy_king::<WHITE>(&self.pawn_structure)
+                - board.passers_enemy_king::<BLACK>(&self.pawn_structure);
+        }
+
+        if piece.is_bishop() {
+            self.bishop_pair = board.bishop_pair::<WHITE>()
+                - board.bishop_pair::<BLACK>();
         }
 
         if piece.is_rook() {
-            self.rook_open_file     = board.rook_open_file::<WHITE>()      - board.rook_open_file::<BLACK>();
-            self.rook_semiopen_file = board.rook_semiopen_file::<WHITE>()  - board.rook_semiopen_file::<BLACK>();
-            self.major_on_seventh   = board.major_on_seventh::<WHITE>()    - board.major_on_seventh::<BLACK>();
+            self.rook_open_file = board.rook_open_file::<WHITE>(&self.pawn_structure)
+                - board.rook_open_file::<BLACK>(&self.pawn_structure);
+
+            self.rook_semiopen_file = board.rook_semiopen_file::<WHITE>(&self.pawn_structure)
+                - board.rook_semiopen_file::<BLACK>(&self.pawn_structure);
+
+            self.major_on_seventh = board.major_on_seventh::<WHITE>()
+                - board.major_on_seventh::<BLACK>();
         }
 
         if piece.is_queen() {
-            self.queen_open_file     = board.queen_open_file::<WHITE>()      - board.queen_open_file::<BLACK>();
-            self.queen_semiopen_file = board.queen_semiopen_file::<WHITE>()  - board.queen_semiopen_file::<BLACK>();
-            self.major_on_seventh    = board.major_on_seventh::<WHITE>()     - board.major_on_seventh::<BLACK>();
+            self.queen_open_file = board.queen_open_file::<WHITE>(&self.pawn_structure)
+                - board.queen_open_file::<BLACK>(&self.pawn_structure);
+
+            self.queen_semiopen_file = board.queen_semiopen_file::<WHITE>(&self.pawn_structure)
+                - board.queen_semiopen_file::<BLACK>(&self.pawn_structure);
+
+            self.major_on_seventh = board.major_on_seventh::<WHITE>()
+                - board.major_on_seventh::<BLACK>();
         }
 
         if piece.is_king() {
-            self.pawn_shield           = board.pawn_shield::<WHITE>()           - board.pawn_shield::<BLACK>();
-            self.pawn_storm            = board.pawn_storm::<WHITE>()            - board.pawn_storm::<BLACK>();
-            self.passers_friendly_king = board.passers_friendly_king::<WHITE>() - board.passers_friendly_king::<BLACK>();
-            self.passers_enemy_king    = board.passers_enemy_king::<WHITE>()    - board.passers_enemy_king::<BLACK>();
-            self.major_on_seventh      = board.major_on_seventh::<WHITE>()      - board.major_on_seventh::<BLACK>();
-        }
-    }
+            self.pawn_shield = board.pawn_shield::<WHITE>()
+                - board.pawn_shield::<BLACK>();
 
+            self.pawn_storm = board.pawn_storm::<WHITE>()
+                - board.pawn_storm::<BLACK>();
+
+            self.passers_friendly_king = board.passers_friendly_king::<WHITE>(&self.pawn_structure)
+                - board.passers_friendly_king::<BLACK>(&self.pawn_structure);
+
+            self.passers_enemy_king = board.passers_enemy_king::<WHITE>(&self.pawn_structure)
+                - board.passers_enemy_king::<BLACK>(&self.pawn_structure);
+
+            self.major_on_seventh = board.major_on_seventh::<WHITE>()
+                - board.major_on_seventh::<BLACK>();
+        }
+
+    }
 
     /// Values assignd to each piece type to calculate the approximate stage 
     /// of the game
@@ -366,27 +343,26 @@ trait Evaluate {
     fn material(&self, piece: Piece) -> S;
     fn psqt(&self, piece: Piece, sq: Square) -> S;
 
-    fn pawn_structure<const WHITE: bool>(&self) -> S;
     fn pawn_shield<const WHITE: bool>(&self) -> S;
     fn pawn_storm<const WHITE: bool>(&self) -> S;
-    fn passers_friendly_king<const WHITE: bool>(&self) -> S;
-    fn passers_enemy_king<const WHITE: bool>(&self) -> S;
+    fn passers_friendly_king<const WHITE: bool>(&self, pawn_structure: &PawnStructure) -> S;
+    fn passers_enemy_king<const WHITE: bool>(&self, pawn_structure: &PawnStructure) -> S;
 
     fn bishop_pair<const WHITE: bool>(&self) -> S;
 
-    fn rook_open_file<const WHITE: bool>(&self) -> S;
-    fn rook_semiopen_file<const WHITE: bool>(&self) -> S;
+    fn rook_open_file<const WHITE: bool>(&self, pawn_structure: &PawnStructure) -> S;
+    fn rook_semiopen_file<const WHITE: bool>(&self, pawn_structure: &PawnStructure) -> S;
     fn connected_rooks<const WHITE: bool>(&self) -> S;
 
-    fn queen_open_file<const WHITE: bool>(&self) -> S;
-    fn queen_semiopen_file<const WHITE: bool>(&self) -> S;
+    fn queen_open_file<const WHITE: bool>(&self, pawn_structure: &PawnStructure) -> S;
+    fn queen_semiopen_file<const WHITE: bool>(&self, pawn_structure: &PawnStructure) -> S;
 
     fn major_on_seventh<const WHITE: bool>(&self) -> S;
 
     fn virtual_mobility<const WHITE: bool>(&self) -> S;
     fn king_zone<const WHITE: bool>(&self, ctx: &mut EvalContext) -> S;
 
-    fn mobility<const WHITE: bool>(&self, ctx: &mut EvalContext) -> S;
+    fn mobility<const WHITE: bool>(&self, ctx: &mut EvalContext, pawn_structure: &PawnStructure) -> S;
 }
 
 impl Evaluate for Board {
@@ -404,54 +380,6 @@ impl Evaluate for Board {
         } else {
             -PIECE_SQUARE_TABLES[piece.piece_type() as usize][sq as usize]
         }
-    }
-
-    fn pawn_structure<const WHITE: bool>(&self) -> S {
-        let mut total = S::default();
-
-        let us = if WHITE { White } else { Black };
-        let our_pawns = self.pawns(us);
-        let their_pawns = self.pawns(!us);
-
-        for sq in our_pawns {
-            // Passed pawns
-            let passed_mask = PASSED_PAWN_MASKS[us as usize][sq as usize];
-            if their_pawns & passed_mask == Bitboard::EMPTY {
-                let sq = if us.is_white() { sq.flip() } else { sq };
-                total += PASSED_PAWN_TABLE[sq as usize];
-            }
-
-            // Connected pawns
-            let connected = (our_pawns & sq.pawn_attacks(us)).count();
-            total += CONNECTED_PAWN_BONUS[connected as usize];
-
-            // Phalanx pawns
-            let neighbors = Bitboard::from(sq).left() | Bitboard::from(sq).right();
-            let phalanx_pawns = our_pawns & neighbors;
-            let phalanx_count = phalanx_pawns.count();
-            total += PHALANX_PAWN_BONUS[phalanx_count as usize];
-
-            // Isolated pawns
-            let isolated_mask = ISOLATED_PAWN_MASKS[sq as usize];
-            if our_pawns & isolated_mask == Bitboard::EMPTY {
-                total += ISOLATED_PAWN_PENALTY;
-            }
-
-            // Doubled pawns
-            // FIXME: Doesn't seem to be correct?
-            // let is_doubled = (our_pawns & FILES[sq as usize]).count() > 1;
-            // if is_doubled {
-            //     total += DOUBLED_PAWN_PENALTY;
-            // }
-        }
-
-        // Doubled pawns
-        for mask in DOUBLED_PAWN_MASKS {
-            let doubled = (our_pawns & mask).count().saturating_sub(1) as Score;
-            total += DOUBLED_PAWN_PENALTY * doubled;
-        }
-
-        total
     }
 
     fn pawn_shield<const WHITE: bool>(&self) -> S {
@@ -490,37 +418,29 @@ impl Evaluate for Board {
         total
     }
 
-    fn passers_friendly_king<const WHITE: bool>(&self) -> S {
+    fn passers_friendly_king<const WHITE: bool>(&self, pawn_structure: &PawnStructure) -> S {
         let mut total = S::default();
 
         let us = if WHITE { White } else { Black };
         let our_king = self.kings(us).first();
-        let our_pawns = self.pawns(us);
-        let their_pawns = self.pawns(!us);
 
-        for pawn in our_pawns {
-            if (PASSED_PAWN_MASKS[us as usize][pawn as usize] & their_pawns).is_empty() {
-                let distance = pawn.max_dist(our_king);
-                total += PASSERS_FRIENDLY_KING_BONUS[distance - 1];
-            }
+        for passer in pawn_structure.passed_pawns(us) {
+            let distance = passer.max_dist(our_king);
+            total += PASSERS_FRIENDLY_KING_BONUS[distance - 1];
         }
 
         total
     }
 
-    fn passers_enemy_king<const WHITE: bool>(&self) -> S {
+    fn passers_enemy_king<const WHITE: bool>(&self, pawn_structure: &PawnStructure) -> S {
         let mut total = S::default();
 
         let us = if WHITE { White } else { Black };
-        let our_pawns = self.pawns(us);
-        let their_pawns = self.pawns(!us);
         let their_king = self.kings(!us).first();
 
-        for pawn in our_pawns {
-            if (PASSED_PAWN_MASKS[us as usize][pawn as usize] & their_pawns).is_empty() {
-                let distance = pawn.max_dist(their_king);
-                total += PASSERS_ENEMY_KING_PENALTY[distance - 1];
-            }
+        for passer in pawn_structure.passed_pawns(us) {
+            let distance = passer.max_dist(their_king);
+            total += PASSERS_ENEMY_KING_PENALTY[distance - 1];
         }
 
         total
@@ -537,35 +457,16 @@ impl Evaluate for Board {
         }
     }
 
-    fn rook_open_file<const WHITE: bool>(&self) -> S {
-        use PieceType::*;
-        let mut total = S::default();
-
+    fn rook_open_file<const WHITE: bool>(&self, pawn_structure: &PawnStructure) -> S {
         let us = if WHITE { White } else { Black };
-        let pawns = self.piece_bbs[Pawn as usize];
-
-        for sq in self.rooks(us) {
-            if (FILES[sq as usize] & pawns).is_empty() {
-                total += ROOK_OPEN_FILE_BONUS;
-            }
-        }
-
-        total
+        let rooks_on_open = self.rooks(us) & pawn_structure.open_files();
+        ROOK_OPEN_FILE_BONUS * rooks_on_open.count() as i32
     }
 
-    fn rook_semiopen_file<const WHITE: bool>(&self) -> S {
-        let mut total = S::default();
-
+    fn rook_semiopen_file<const WHITE: bool>(&self, pawn_structure: &PawnStructure) -> S {
         let us = if WHITE { White } else { Black };
-        let pawns = self.pawns(us);
-
-        for sq in self.rooks(us) {
-            if (FILES[sq as usize] & pawns).is_empty() {
-                total += ROOK_SEMIOPEN_FILE_BONUS;
-            }
-        }
-
-        total
+        let rooks_on_semi = self.rooks(us) & pawn_structure.semi_open_files(us);
+        ROOK_SEMIOPEN_FILE_BONUS * rooks_on_semi.count() as i32
     }
 
     fn connected_rooks<const WHITE: bool>(&self) -> S {
@@ -607,55 +508,27 @@ impl Evaluate for Board {
         total
     }
 
-    fn queen_open_file<const WHITE: bool>(&self) -> S {
-        use PieceType::*;
-        let mut total = S::default();
-
+    fn queen_open_file<const WHITE: bool>(&self, pawn_structure: &PawnStructure) -> S {
         let us = if WHITE { White } else { Black };
-        let pawns = self.piece_bbs[Pawn as usize];
-
-        for sq in self.queens(us) {
-            if (FILES[sq as usize] & pawns).is_empty() {
-                total += QUEEN_OPEN_FILE_BONUS;
-            }
-        }
-
-        total
+        let queens_on_open = self.queens(us) & pawn_structure.open_files();
+        QUEEN_OPEN_FILE_BONUS * queens_on_open.count() as i32
     }
 
-    fn queen_semiopen_file<const WHITE: bool>(&self) -> S {
-        let mut total = S::default();
+    fn queen_semiopen_file<const WHITE: bool>(&self, pawn_structure: &PawnStructure) -> S {
         let us = if WHITE { White } else { Black };
-
-        let our_pawns = self.pawns(us);
-        let their_pawns = self.pawns(!us);
-
-        for sq in self.queens(us) {
-            if (FILES[sq as usize] & our_pawns).is_empty() 
-                && FILES[sq as usize] & their_pawns != Bitboard::EMPTY {
-                total += QUEEN_SEMIOPEN_FILE_BONUS;
-            }
-        }
-
-        total
+        let queens_on_semi = self.queens(us) & pawn_structure.semi_open_files(us);
+        QUEEN_SEMIOPEN_FILE_BONUS * queens_on_semi.count() as i32
     }
 
-    fn mobility<const WHITE: bool>(&self, ctx: &mut EvalContext) -> S {
+    fn mobility<const WHITE: bool>(&self, ctx: &mut EvalContext, pawn_structure: &PawnStructure) -> S {
         let mut total = S::default();
 
         let us = if WHITE { White } else { Black };
         let blockers = self.all_occupied();
         let enemy_king_zone = ctx.king_zones[!us as usize];
 
-        let pawn_attacks: Bitboard = self.pawns(!us)
-            .map(|sq| sq.pawn_attacks(!us))
-            .collect();
-
-        let blocked_pawns = if WHITE {
-            self.pawns(us) & (self.pawns(!us) >> 8)
-        } else {
-            self.pawns(us) & (self.pawns(!us) << 8)
-        };
+        let pawn_attacks = pawn_structure.pawn_attacks(!us);
+        let blocked_pawns = pawn_structure.blocked_pawns(us);
 
         let mobility_squares = !pawn_attacks & !blocked_pawns;
 
@@ -758,6 +631,8 @@ impl Evaluate for Board {
 //
 // Weights
 //
+// Utility helpers for our custom tapered scores
+//
 ////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
@@ -826,6 +701,9 @@ impl Sum for S {
 ////////////////////////////////////////////////////////////////////////////////
 //
 // Score
+//
+// Extension trait that allows us to put some additional helper methods on 
+// the Score type alias (recall, Score is just an alias for i32).
 //
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/simbelmyne/src/evaluate/pawn_structure.rs
+++ b/simbelmyne/src/evaluate/pawn_structure.rs
@@ -140,7 +140,7 @@ impl PawnStructure {
             total += CONNECTED_PAWN_BONUS[connected as usize];
 
             // Phalanx pawns
-            let neighbors = Bitboard::from(sq.left()) | Bitboard::from(sq.right());
+            let neighbors = Bitboard::from(sq).left() | Bitboard::from(sq).right();
             let phalanx_pawns = our_pawns & neighbors;
             let phalanx_count = phalanx_pawns.count();
             total += PHALANX_PAWN_BONUS[phalanx_count as usize];

--- a/simbelmyne/src/evaluate/pawn_structure.rs
+++ b/simbelmyne/src/evaluate/pawn_structure.rs
@@ -1,0 +1,165 @@
+use chess::bitboard::Bitboard;
+use chess::board::Board;
+use chess::piece::Color;
+use chess::piece::Color::*;
+
+use crate::evaluate::lookups::PASSED_PAWN_MASKS;
+
+use super::lookups::{DOUBLED_PAWN_MASKS, FILES, ISOLATED_PAWN_MASKS};
+use super::params::{CONNECTED_PAWN_BONUS, DOUBLED_PAWN_PENALTY, ISOLATED_PAWN_PENALTY, PASSED_PAWN_TABLE, PHALANX_PAWN_BONUS};
+use super::{Score, S};
+
+const WHITE: bool = true;
+const BLACK: bool = false;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub struct PawnStructure {
+    /// The score associated with the pawn structure
+    score: S,
+
+    /// Pawn bitboards for White and Black
+    pawns: [Bitboard; Color::COUNT],
+
+    /// Pawn attacks bitboards for White and Black
+    pawn_attacks: [Bitboard; Color::COUNT],
+
+    /// Passed pawn bitboards for White and Black
+    passed_pawns: [Bitboard; Color::COUNT],
+
+    /// Semi-open file bitboards for White and Black
+    semi_open_files: [Bitboard; Color::COUNT],
+
+    /// Blocked pawns bitboards for White and Black
+    blocked_pawns: [Bitboard; Color::COUNT],
+}
+
+impl PawnStructure {
+    pub fn new(board: &Board) -> Self {
+        let white_pawns = board.pawns(White);
+        let black_pawns = board.pawns(Black);
+
+        let white_attacks = ((white_pawns & !FILES[0]) << 7) 
+            | ((white_pawns & !FILES[7]) << 9);
+
+        let black_attacks = ((black_pawns & !FILES[0]) >> 7) 
+            | ((white_pawns & !FILES[7]) >> 9);
+
+        let white_passers = white_pawns
+            .filter(|&pawn| {
+                let mask = PASSED_PAWN_MASKS[White as usize][pawn as usize];
+                (mask & black_pawns).is_empty()
+            })
+            .collect::<Bitboard>();
+
+        let black_passers = black_pawns
+            .filter(|&pawn| {
+                let mask = PASSED_PAWN_MASKS[Black as usize][pawn as usize];
+                (mask & white_pawns).is_empty()
+            })
+            .collect::<Bitboard>();
+
+        let white_semi_open_files = FILES[0..7].iter()
+            .filter(|&&file| {
+                (file & white_pawns).is_empty()
+            })
+            .collect::<Bitboard>();
+
+        let black_semi_open_files = FILES[0..7].iter()
+            .filter(|&&file| {
+                (file & black_pawns).is_empty()
+            })
+            .collect::<Bitboard>();
+
+        let white_blocked_pawns = white_pawns & black_pawns >> 8;
+        let black_blocked_pawns = black_pawns & white_pawns << 8;
+
+        let mut pawn_structure = Self {
+            score: S::default(),
+            pawns: [ white_pawns, black_pawns],
+            pawn_attacks: [white_attacks, black_attacks],
+            passed_pawns: [white_passers, black_passers],
+            semi_open_files: [white_semi_open_files, black_semi_open_files],
+            blocked_pawns: [white_blocked_pawns, black_blocked_pawns],
+        };
+
+        pawn_structure.score = pawn_structure.compute_score::<WHITE>() - pawn_structure.compute_score::<BLACK>();
+
+        pawn_structure
+    }
+
+    pub fn score(&self) -> S {
+        self.score
+    }
+
+    pub fn pawns(&self, us: Color) -> Bitboard {
+        self.pawns[us as usize]
+    }
+
+    pub fn pawn_attacks(&self, us: Color) -> Bitboard {
+        self.pawn_attacks[us as usize]
+    }
+
+    pub fn passed_pawns(&self, us: Color) -> Bitboard {
+        self.passed_pawns[us as usize]
+    }
+
+    pub fn semi_open_files(&self, us: Color) -> Bitboard {
+        self.semi_open_files[us as usize]
+    }
+
+    pub fn open_files(&self) -> Bitboard {
+        self.semi_open_files(White) & self.semi_open_files(Black)
+    }
+
+    pub fn blocked_pawns(&self, us: Color) -> Bitboard {
+        self.blocked_pawns[us as usize]
+    }
+
+    pub fn compute_score<const WHITE: bool>(&self) -> S {
+        let mut total = S::default();
+
+        let us = if WHITE { White } else { Black };
+        let our_pawns = self.pawns(us);
+        let their_pawns = self.pawns(!us);
+
+        for sq in our_pawns {
+            // Passed pawns
+            let passed_mask = PASSED_PAWN_MASKS[us as usize][sq as usize];
+            if their_pawns & passed_mask == Bitboard::EMPTY {
+                let sq = if us.is_white() { sq.flip() } else { sq };
+                total += PASSED_PAWN_TABLE[sq as usize];
+            }
+
+            // Connected pawns
+            let connected = (our_pawns & sq.pawn_attacks(us)).count();
+            total += CONNECTED_PAWN_BONUS[connected as usize];
+
+            // Phalanx pawns
+            let neighbors = Bitboard::from(sq.left()) | Bitboard::from(sq.right());
+            let phalanx_pawns = our_pawns & neighbors;
+            let phalanx_count = phalanx_pawns.count();
+            total += PHALANX_PAWN_BONUS[phalanx_count as usize];
+
+            // Isolated pawns
+            let isolated_mask = ISOLATED_PAWN_MASKS[sq as usize];
+            if our_pawns & isolated_mask == Bitboard::EMPTY {
+                total += ISOLATED_PAWN_PENALTY;
+            }
+
+            // Doubled pawns
+            // FIXME: Doesn't seem to be correct?
+            // let is_doubled = (our_pawns & FILES[sq as usize]).count() > 1;
+            // if is_doubled {
+            //     total += DOUBLED_PAWN_PENALTY;
+            // }
+        }
+
+        // Doubled pawns
+        for mask in DOUBLED_PAWN_MASKS {
+            let doubled = (our_pawns & mask).count().saturating_sub(1) as Score;
+            total += DOUBLED_PAWN_PENALTY * doubled;
+        }
+
+        total
+    }
+}

--- a/simbelmyne/src/evaluate/pretty_print.rs
+++ b/simbelmyne/src/evaluate/pretty_print.rs
@@ -1,0 +1,142 @@
+use chess::{board::Board, square::Square};
+use colored::Colorize;
+
+use crate::evaluate::Evaluate;
+
+use super::{Eval, EvalContext};
+
+const WHITE: bool = true;
+const BLACK: bool = false;
+
+fn blank_line(rank: usize) -> String {
+        let mut line: Vec<String> = Vec::new();
+        line.push("  ║".to_string());
+    if rank % 2 == 0 {
+        line.push("       ".on_white().to_string());
+        line.push("       ".on_black().to_string());
+        line.push("       ".on_white().to_string());
+        line.push("       ".on_black().to_string());
+        line.push("       ".on_white().to_string());
+        line.push("       ".on_black().to_string());
+        line.push("       ".on_white().to_string());
+        line.push("       ".on_black().to_string());
+    } else {
+        line.push("       ".on_black().to_string());
+        line.push("       ".on_white().to_string());
+        line.push("       ".on_black().to_string());
+        line.push("       ".on_white().to_string());
+        line.push("       ".on_black().to_string());
+        line.push("       ".on_white().to_string());
+        line.push("       ".on_black().to_string());
+        line.push("       ".on_white().to_string());
+    }
+
+    line.push("║ ".to_string());
+    line.join("")
+}
+
+pub fn print_eval(board: &Board) -> String {
+    let eval = Eval::new(board);
+
+    let mut lines: Vec<String> = vec![];
+    lines.push("      a      b      c      d      e      f      g      h    ".to_string());
+    lines.push("  ╔════════════════════════════════════════════════════════╗".to_string());
+
+    for (rank, squares) in Square::RANKS.into_iter().enumerate() {
+        lines.push(blank_line(rank));
+
+        // Piece character
+        let mut line: Vec<String> = vec![];
+        line.push((8 - rank).to_string());
+        line.push(" ║".to_string());
+        for (file, sq) in squares.into_iter().enumerate() {
+            let bg = if (rank + file) % 2 == 0 { "white" } else { "black" };
+            let fg = if (rank + file) % 2 == 0 { "black" } else { "white" };
+
+            let square = match board.get_at(sq) {
+                Some(piece) => format!("   {}   ", piece).color(fg).on_color(bg),
+                None => "       ".to_string().on_color(bg),
+            };
+
+            line.push(square.to_string());
+        }
+        line.push("║ ".to_string());
+        line.push((8 - rank).to_string());
+        lines.push(line.join(""));
+
+        lines.push(blank_line(rank));
+
+        // Piece score
+        let mut line: Vec<String> = vec![];
+        line.push("  ║".to_string());
+        for (file, sq) in squares.into_iter().enumerate() {
+            let bg = if (rank + file) % 2 == 0 { "white" } else { "black" };
+            let fg = if (rank + file) % 2 == 0 { "black" } else { "white" };
+            let score = if let Some(piece) = board.get_at(sq) {
+                // Get score for piece
+                let score = board.material(piece) + board.psqt(piece, sq);
+                let pawn_score = score.lerp(eval.game_phase) as f32 / 100.0;
+
+                format!("{:.2}", pawn_score)
+            } else {
+                "".to_string()
+            };
+
+            line.push(format!("{:^7}", score.color(fg).on_color(bg)));
+            
+        }
+        line.push("║  ".to_string());
+        let line = line.join("");
+
+        lines.push(line);
+
+
+    }
+    lines.push("  ╚════════════════════════════════════════════════════════╝".to_string());
+    lines.push("      a      b      c      d      e      f      g      h    ".to_string());
+
+    lines.push("\n".to_string());
+    lines.push("Evaluation features:".blue().to_string());
+    lines.push("--------------------".blue().to_string());
+
+    let mut ctx = EvalContext::new(board);
+
+    let white_pawn_structure =  eval.pawn_structure.compute_score::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
+    let black_pawn_structure = -eval.pawn_structure.compute_score::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
+    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Pawn structure:", white_pawn_structure, black_pawn_structure));
+
+    let white_bishop_pair =  board.bishop_pair::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
+    let black_bishop_pair = -board.bishop_pair::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
+    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Bishop pair", white_bishop_pair, black_bishop_pair));
+
+    let white_rook_open_file =  board.rook_open_file::<WHITE>(&eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
+    let black_rook_open_file = -board.rook_open_file::<BLACK>(&eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
+    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Rook on open file:", white_rook_open_file, black_rook_open_file));
+
+    let white_pawn_shield =  board.pawn_shield::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
+    let black_pawn_shield = -board.pawn_shield::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
+    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Pawn shield:", white_pawn_shield, black_pawn_shield));
+
+    let white_pawn_storm =  board.pawn_storm::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
+    let black_pawn_storm = -board.pawn_storm::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
+    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Pawn storm:", white_pawn_storm, black_pawn_storm));
+
+    let white_mobility =  board.mobility::<WHITE>(&mut ctx, &eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
+    let black_mobility = -board.mobility::<BLACK>(&mut ctx, &eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
+    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Mobility:", white_mobility, black_mobility));
+
+    let white_virtual_mobility =  board.virtual_mobility::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
+    let black_virtual_mobility = -board.virtual_mobility::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
+    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Virtual mobility:", white_virtual_mobility, black_virtual_mobility));
+
+    let white_king_zone =  board.king_zone::<WHITE>(&mut ctx).lerp(eval.game_phase) as f32 / 100.0;
+    let black_king_zone = -board.king_zone::<BLACK>(&mut ctx).lerp(eval.game_phase) as f32 / 100.0;
+    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "King zone:", white_king_zone, black_king_zone));
+
+    lines.push("".to_string());
+
+    lines.push(format!("Total: {}", eval.total(&board)));
+
+    lines.join("\n")
+}
+

--- a/simbelmyne/src/evaluate/pretty_print.rs
+++ b/simbelmyne/src/evaluate/pretty_print.rs
@@ -103,35 +103,63 @@ pub fn print_eval(board: &Board) -> String {
 
     let white_pawn_structure =  eval.pawn_structure.compute_score::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
     let black_pawn_structure = -eval.pawn_structure.compute_score::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Pawn structure:", white_pawn_structure, black_pawn_structure));
+    lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Pawn structure:", white_pawn_structure, black_pawn_structure));
 
     let white_bishop_pair =  board.bishop_pair::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
     let black_bishop_pair = -board.bishop_pair::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Bishop pair", white_bishop_pair, black_bishop_pair));
+    lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Bishop pair", white_bishop_pair, black_bishop_pair));
 
     let white_rook_open_file =  board.rook_open_file::<WHITE>(&eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
     let black_rook_open_file = -board.rook_open_file::<BLACK>(&eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Rook on open file:", white_rook_open_file, black_rook_open_file));
+    lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Rook on open file:", white_rook_open_file, black_rook_open_file));
+
+    let white_rook_semiopen_file =  board.rook_semiopen_file::<WHITE>(&eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
+    let black_rook_semiopen_file = -board.rook_semiopen_file::<BLACK>(&eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
+    lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Rook on semiopen file:", white_rook_semiopen_file, black_rook_semiopen_file));
+
+    let white_connected_rooks =  board.connected_rooks::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
+    let black_connected_rooks = -board.connected_rooks::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
+    lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Connected rooks:", white_connected_rooks, black_connected_rooks));
+
+    let white_queen_open_file =  board.queen_open_file::<WHITE>(&eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
+    let black_queen_open_file = -board.queen_open_file::<BLACK>(&eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
+    lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Queen on open file:", white_queen_open_file, black_queen_open_file));
+
+    let white_queen_semiopen_file =  board.queen_semiopen_file::<WHITE>(&eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
+    let black_queen_semiopen_file = -board.queen_semiopen_file::<BLACK>(&eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
+    lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Queen on semiopen file:", white_queen_semiopen_file, black_queen_semiopen_file));
+
+    let white_major_on_7th =  board.major_on_seventh::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
+    let black_major_on_7th = -board.major_on_seventh::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
+    lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Major on 7th:", white_major_on_7th, black_major_on_7th));
 
     let white_pawn_shield =  board.pawn_shield::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
     let black_pawn_shield = -board.pawn_shield::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Pawn shield:", white_pawn_shield, black_pawn_shield));
+    lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Pawn shield:", white_pawn_shield, black_pawn_shield));
 
     let white_pawn_storm =  board.pawn_storm::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
     let black_pawn_storm = -board.pawn_storm::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Pawn storm:", white_pawn_storm, black_pawn_storm));
+    lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Pawn storm:", white_pawn_storm, black_pawn_storm));
+
+    let white_passers_friendly_king =  board.passers_friendly_king::<WHITE>(&eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
+    let black_passers_friendly_king = -board.passers_friendly_king::<BLACK>(&eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
+    lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Passers - Friendly king:", white_passers_friendly_king, black_passers_friendly_king));
+
+    let white_passers_enemy_king =  board.passers_enemy_king::<WHITE>(&eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
+    let black_passers_enemy_king = -board.passers_enemy_king::<BLACK>(&eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
+    lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Passers - Enemy king:", white_passers_enemy_king, black_passers_enemy_king));
 
     let white_mobility =  board.mobility::<WHITE>(&mut ctx, &eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
     let black_mobility = -board.mobility::<BLACK>(&mut ctx, &eval.pawn_structure).lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Mobility:", white_mobility, black_mobility));
+    lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Mobility:", white_mobility, black_mobility));
 
     let white_virtual_mobility =  board.virtual_mobility::<WHITE>().lerp(eval.game_phase) as f32 / 100.0;
     let black_virtual_mobility = -board.virtual_mobility::<BLACK>().lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "Virtual mobility:", white_virtual_mobility, black_virtual_mobility));
+    lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Virtual mobility:", white_virtual_mobility, black_virtual_mobility));
 
     let white_king_zone =  board.king_zone::<WHITE>(&mut ctx).lerp(eval.game_phase) as f32 / 100.0;
     let black_king_zone = -board.king_zone::<BLACK>(&mut ctx).lerp(eval.game_phase) as f32 / 100.0;
-    lines.push(format!("{:<20} {:>7.2} {:>7.2}", "King zone:", white_king_zone, black_king_zone));
+    lines.push(format!("{:<25} {:>7.2} {:>7.2}", "King zone:", white_king_zone, black_king_zone));
 
     lines.push("".to_string());
 

--- a/simbelmyne/src/position.rs
+++ b/simbelmyne/src/position.rs
@@ -121,6 +121,21 @@ impl Position {
 
         ////////////////////////////////////////////////////////////////////////
         //
+        // Coptures
+        //
+        ////////////////////////////////////////////////////////////////////////
+
+        if mv.is_capture() {
+            let captured_sq = mv.get_capture_sq();
+            let captured = self.board.get_at(captured_sq)
+                .expect("Move is a capture, so must have piece on target");
+ 
+            new_score.remove(captured, captured_sq, &new_board);
+            new_hash.toggle_piece(captured, captured_sq);
+        }
+
+        ////////////////////////////////////////////////////////////////////////
+        //
         // Move piece
         //
         ////////////////////////////////////////////////////////////////////////
@@ -146,25 +161,10 @@ impl Position {
 
         ////////////////////////////////////////////////////////////////////////
         //
-        // Coptures
-        //
-        ////////////////////////////////////////////////////////////////////////
-        
-        if mv.is_capture() {
-            let captured_sq = mv.get_capture_sq();
-            let captured = self.board.get_at(captured_sq)
-                .expect("Move is a capture, so must have piece on target");
- 
-            new_score.remove(captured, captured_sq, &new_board);
-            new_hash.toggle_piece(captured, captured_sq);
-        }
-
-        ////////////////////////////////////////////////////////////////////////
-        //
         // Castling
         //
         ////////////////////////////////////////////////////////////////////////
-        
+
         // If castle: also account for the rook having moved
         if mv.is_castle() {
             let ctype = CastleType::from_move(mv).unwrap();

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -16,7 +16,7 @@ use colored::Colorize;
 use uci::client::UciClientMessage;
 use uci::options::OptionType;
 use uci::options::UciOption;
-use crate::evaluate::print_eval;
+use crate::evaluate::pretty_print::print_eval;
 use crate::evaluate::Score;
 use crate::search::params::DEFAULT_TT_SIZE;
 use chess::perft::perft_divide;


### PR DESCRIPTION
Not nearly as much as I'd expected, but okay...

Still a speed-up across the board, so I'd be a fool not to take it.

```
Score of Simbelmyne vs Simbelmyne main: 716 - 677 - 1106 [0.508]
...      Simbelmyne playing White: 365 - 345 - 539  [0.508] 1249
...      Simbelmyne playing Black: 351 - 332 - 567  [0.508] 1250
...      White vs Black: 697 - 696 - 1106  [0.500] 2499
Elo difference: 5.4 +/- 10.2, LOS: 85.2 %, DrawRatio: 44.3 %
```

Should open the door to some more optimizations

1. Can I replace the current Phalanx scoring with a fixed score (instead of 0,1,2 scores)
2. Can I replace the current connected pawn scoring with a fixed score (instead of 0,1,2 scores)
3. Can I cache these pawn structure terms?