### PR TITLE
Add manual contempt factor

### DIFF
--- a/simbelmyne/src/evaluate/mod.rs
+++ b/simbelmyne/src/evaluate/mod.rs
@@ -163,6 +163,8 @@ pub struct Eval {
 }
 
 impl Eval {
+    const CONTEMPT: S = S(-50, -10);
+
     /// Create a new score for a board
     pub fn new(board: &Board) -> Self {
         let mut eval = Self::default();
@@ -349,6 +351,12 @@ impl Eval {
     /// 0 corresponds to endgame, 24 corresponds to midgame
     fn phase_value(piece: Piece) -> u8 {
         Self::GAME_PHASE_VALUES[piece.piece_type() as usize]
+    }
+
+    pub fn draw_score(self, nodes: u32) -> Score {
+        let random = nodes as Score & 0b11 - 2;
+
+        -Self::CONTEMPT.lerp(self.game_phase) + random
     }
 }
 
@@ -810,7 +818,6 @@ impl Sum for S {
 pub trait ScoreExt {
     const MINUS_INF: Self;
     const PLUS_INF: Self;
-    const DRAW: Self;
     const MATE: Self;
 
     /// Return whether or not a score is a mate score
@@ -831,7 +838,6 @@ pub trait ScoreExt {
 impl ScoreExt for Score {
     const MINUS_INF: Self = Self::MIN + 1;
     const PLUS_INF: Self = Self::MAX;
-    const DRAW: Self = 0;
     const MATE: Self = 20_000;
 
     fn is_mate(self) -> bool {

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -95,7 +95,7 @@ impl Position {
         // Don't return early when in the root node, because we won't have a PV 
         // move to play.
         if !in_root && (self.board.is_rule_draw() || self.is_repetition()) {
-            return Score::DRAW;
+            return self.score.draw_score(search.tc.nodes());
         }
 
         ////////////////////////////////////////////////////////////////////////
@@ -244,7 +244,7 @@ impl Position {
 
         // Stalemate?
         if legal_moves.len() == 0 && !in_check {
-            return Score::DRAW;
+            return self.score.draw_score(search.tc.nodes());
         }
 
         ////////////////////////////////////////////////////////////////////////

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -69,7 +69,6 @@ impl Default for SearchParams {
             lmr_threshold: LMR_THRESHOLD,
 
             delta_pruning_margin: DELTA_PRUNING_MARGIN,
-
         }
     }
 }
@@ -97,7 +96,7 @@ pub const SEE_ORDERING     : bool = true;
 ////////////////////////////////////////////////////////////////////////////////
 
 pub const DEFAULT_TT_SIZE: usize = 64;
-pub const MAX_DEPTH           : usize = 128;
+pub const MAX_DEPTH: usize = 128;
 
 // Null-move pruning
 const NMP_BASE_REDUCTION: usize = 2;

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -43,7 +43,7 @@ impl Position {
         search.seldepth = search.seldepth.max(ply);
 
         if self.board.is_rule_draw() || self.is_repetition() {
-            return Score::DRAW;
+            return self.score.draw_score(search.tc.nodes());
         }
 
         let in_check = self.board.in_check();


### PR DESCRIPTION
Not exposing it as a UCI option for now, because I don't like the way it feels...

Seems to make a big difference for 3-fold repetitions, but those are seemingly just converted into insufficient material draws.

I wonder what happens when we combine both

```
Rank Name                          Elo     +/-   Games   Score    Draw
   0 Simbelmyne v1.5.1 (2696)      -73       8    5000   39.6%   33.9%
   1 Simbelmyne                     74      11    2500   60.6%   33.0%
   2 Simbelmyne main                72      11    2500   60.3%   34.8%

SPRT: llr 0 (0.0%), lbound -inf, ubound inf
5000 of 5000 games finished.

Player: Simbelmyne v1.5.1 (2696)
   "Draw by 3-fold repetition": 1001
   "Draw by fifty moves rule": 256
   "Draw by insufficient mating material": 411
   "Draw by stalemate": 28
   "Loss: Black mates": 1081
   "Loss: White mates": 1092
   "Win: Black mates": 552
   "Win: White mates": 579
Player: Simbelmyne
   "Draw by 3-fold repetition": 436
   "Draw by fifty moves rule": 123
   "Draw by insufficient mating material": 252
   "Draw by stalemate": 15
   "Loss: Black mates": 280
   "Loss: White mates": 293
   "Win: Black mates": 542
   "Win: White mates": 559
Player: Simbelmyne main
   "Draw by 3-fold repetition": 565
   "Draw by fifty moves rule": 133
   "Draw by insufficient mating material": 159
   "Draw by stalemate": 13
   "Loss: Black mates": 272
   "Loss: White mates": 286
   "Win: Black mates": 539
   "Win: White mates": 533
```