### PR TITLE
Reduce bad captures more

### DIFF
--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -346,13 +346,16 @@ impl Position {
 
                     reduction = LMR_TABLE[depth][move_count];
 
+                    // Reduce non-pv nodes more
                     reduction += !PV as usize;
 
-                    reduction += mv.is_quiet() as usize;
+                    // Reduce quiets and bad tacticals more
+                    reduction += (legal_moves.stage() > Stage::GoodTacticals) as usize;
 
-                    // Reduce good tacticals less
-                    reduction -= (legal_moves.stage() < Stage::ScoreQuiets) as usize;
+                    // Reduce bad captures even more
+                    reduction += (legal_moves.stage() > Stage::Quiets) as usize;
 
+                    // Make sure we don't reduce below zero
                     reduction = reduction.clamp(0, depth - 2);
                 }
 


### PR DESCRIPTION
instead of reducing good captures less

```
Score of Simbelmyne vs Simbelmyne main: 926 - 836 - 1186 [0.515]
...      Simbelmyne playing White: 470 - 414 - 591  [0.519] 1475
...      Simbelmyne playing Black: 456 - 422 - 595  [0.512] 1473
...      White vs Black: 892 - 870 - 1186  [0.504] 2948
Elo difference: 10.6 +/- 9.7, LOS: 98.4 %, DrawRatio: 40.2 %
SPRT: llr 0 (0.0%), lbound -inf, ubound inf
2960 of 5000 games finished.

Player: Simbelmyne
   "Draw by 3-fold repetition": 506
   "Draw by fifty moves rule": 297
   "Draw by insufficient mating material": 378
   "Draw by stalemate": 5
   "Loss: Black mates": 414
   "Loss: White mates": 422
   "No result": 12
   "Win: Black mates": 456
   "Win: White mates": 470
Player: Simbelmyne main
   "Draw by 3-fold repetition": 506
   "Draw by fifty moves rule": 297
   "Draw by insufficient mating material": 378
   "Draw by stalemate": 5
   "Loss: Black mates": 456
   "Loss: White mates": 470
   "No result": 12
   "Win: Black mates": 414
   "Win: White mates": 422
```