### PR TITLE
Search/better time management

### DIFF
--- a/simbelmyne/src/time_control.rs
+++ b/simbelmyne/src/time_control.rs
@@ -150,7 +150,7 @@ impl TimeController {
             }, 
 
             TimeControl::Clock { .. } => {
-                self.elapsed() < self.soft_time
+                self.elapsed() < self.hard_time
             },
 
             _ => true,
@@ -175,7 +175,7 @@ impl TimeController {
             },
 
             TimeControl::FixedTime(_) | TimeControl::Clock { .. } => {
-                self.elapsed() < self.hard_time
+                self.elapsed() < self.soft_time
             },
 
             _ => true,

--- a/simbelmyne/src/time_control.rs
+++ b/simbelmyne/src/time_control.rs
@@ -145,8 +145,8 @@ impl TimeController {
                 self.nodes + CHECKUP_WINDOW < max_nodes as u32
             },
 
-            TimeControl::FixedTime(max_time) => {
-                max_time < self.hard_time
+            TimeControl::FixedTime(_time) => {
+                self.elapsed() < self.hard_time
             }, 
 
             TimeControl::Clock { .. } => {
@@ -174,7 +174,11 @@ impl TimeController {
                 self.nodes + CHECKUP_WINDOW < max_nodes as u32
             },
 
-            TimeControl::FixedTime(_) | TimeControl::Clock { .. } => {
+            TimeControl::FixedTime(_) => {
+                self.elapsed() < self.hard_time
+            },
+
+            TimeControl::Clock { .. } => {
                 self.elapsed() < self.soft_time
             },
 


### PR DESCRIPTION
Fix some time management bugs that were causing us to disregard the soft time cutoff.

Another thing I've tried (but failed SPRT) was returning immediately when the position is forced (so it makes no sense to spend all the available time thinking about the next move, since there is only one).

I _guess_ this must be due to the fact that we're still better off searching and populating the TT, than just returning early and having less time to do the same work on the next turn?

```
Score of Simbelmyne vs Simbelmyne main: 925 - 844 - 1270 [0.513]
...      Simbelmyne playing White: 464 - 422 - 633  [0.514] 1519
...      Simbelmyne playing Black: 461 - 422 - 637  [0.513] 1520
...      White vs Black: 886 - 883 - 1270  [0.500] 3039
Elo difference: 9.3 +/- 9.4, LOS: 97.3 %, DrawRatio: 41.8 %
SPRT: llr 0 (0.0%), lbound -inf, ubound inf
3051 of 5000 games finished.

Player: Simbelmyne
   "Draw by 3-fold repetition": 519
   "Draw by fifty moves rule": 344
   "Draw by insufficient mating material": 394
   "Draw by stalemate": 13
   "Loss: Black mates": 422
   "Loss: White mates": 422
   "No result": 12
   "Win: Black mates": 461
   "Win: White mates": 464
Player: Simbelmyne main
   "Draw by 3-fold repetition": 519
   "Draw by fifty moves rule": 344
   "Draw by insufficient mating material": 394
   "Draw by stalemate": 13
   "Loss: Black mates": 461
   "Loss: White mates": 464
   "No result": 12
   "Win: Black mates": 422
   "Win: White mates": 422
```

