### PR TITLE
Move futility pruning into move loop

### DIFF
--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -232,17 +232,12 @@ impl Position {
         // that are unlikely to be able to increase alpha. (i.e., quiet moves).
         //
         ////////////////////////////////////////////////////////////////////////
-
-        if depth <= search.search_params.fp_threshold
-            && eval + search.search_params.fp_margins[depth] <= alpha
-            && !PV
-            && !in_check
-            && legal_moves.count_tacticals() > 0
-            && !alpha.is_mate()
-            && !beta.is_mate()
-        {
-            legal_moves.only_good_tacticals = true;
-        }
+        let should_fp = depth <= search.search_params.fp_threshold
+                && eval + search.search_params.fp_margins[depth] <= alpha
+                && !PV
+                && !in_check
+                && !alpha.is_mate()
+                && !beta.is_mate();
 
         ////////////////////////////////////////////////////////////////////////
         //
@@ -259,6 +254,12 @@ impl Position {
             if !search.tc.should_continue() {
                 search.aborted = true;
                 return Score::MINUS_INF;
+            }
+
+            // Futility pruning
+            if move_count > 0 && should_fp {
+                legal_moves.only_good_tacticals = true;
+                continue;
             }
 
             ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Just so we can more easily guarantee that at least a single move is checked when we do futility pruning and there are no good captures, to prevent us from returning infinite scores and null moves.

```
Score of Simbelmyne vs Simbelmyne main: 1235 - 1095 - 1396 [0.519]
...      Simbelmyne playing White: 593 - 574 - 697  [0.505] 1864
...      Simbelmyne playing Black: 642 - 521 - 699  [0.532] 1862
...      White vs Black: 1114 - 1216 - 1396  [0.486] 3726
Elo difference: 13.1 +/- 8.8, LOS: 99.8 %, DrawRatio: 37.5 %
SPRT: llr 0 (0.0%), lbound -inf, ubound inf
3738 of 5000 games finished.

Player: Simbelmyne
   "Draw by 3-fold repetition": 505
   "Draw by fifty moves rule": 407
   "Draw by insufficient mating material": 469
   "Draw by stalemate": 15
   "Loss: Black mates": 574
   "Loss: White mates": 521
   "No result": 12
   "Win: Black mates": 642
   "Win: White mates": 593
Player: Simbelmyne main
   "Draw by 3-fold repetition": 505
   "Draw by fifty moves rule": 407
   "Draw by insufficient mating material": 469
   "Draw by stalemate": 15
   "Loss: Black mates": 642
   "Loss: White mates": 593
   "No result": 12
   "Win: Black mates": 574
   "Win: White mates": 521
```