### PR TITLE
Reduce `soft_time` to be `hard_time / 3`

### DIFF
--- a/simbelmyne/src/time_control.rs
+++ b/simbelmyne/src/time_control.rs
@@ -100,7 +100,7 @@ impl TimeController {
 
         // Soft time determines when it's no longer worth starting a fresh 
         // search, but it's not quite time to abort an ongoing search.
-        let soft_time = hard_time * 6 / 10;
+        let soft_time = hard_time / 3;
 
         let tc = TimeController {
             tc: tc_type,
@@ -159,6 +159,11 @@ impl TimeController {
 
     /// Check whether we should start a new iterative deepening search.
     pub fn should_start_search(&self, depth: usize) -> bool {
+        // Make sure we always do at least _one_ search iteration.
+        if depth == 1 {
+            return true;
+        }
+
         // Always respect the global stop flag
         if self.stopped() {
             return false;


### PR DESCRIPTION
Makes a big difference. First time I ran into the engine not clearing depth 1 and crashing, though. (At least, that's what I think happened?)

```
Score of Simbelmyne vs Simbelmyne main: 413 - 304 - 453 [0.547]
...      Simbelmyne playing White: 214 - 157 - 214  [0.549] 585
...      Simbelmyne playing Black: 199 - 147 - 239  [0.544] 585
...      White vs Black: 361 - 356 - 453  [0.502] 1170
Elo difference: 32.5 +/- 15.6, LOS: 100.0 %, DrawRatio: 38.7 %
SPRT: llr 0 (0.0%), lbound -inf, ubound inf
1182 of 5000 games finished.

Player: Simbelmyne
   "Draw by 3-fold repetition": 225
   "Draw by fifty moves rule": 96
   "Draw by insufficient mating material": 127
   "Draw by stalemate": 5
   "Loss: Black mates": 157
   "Loss: White mates": 147
   "No result": 12
   "Win: Black mates": 199
   "Win: White mates": 214
Player: Simbelmyne main
   "Draw by 3-fold repetition": 225
   "Draw by fifty moves rule": 96
   "Draw by insufficient mating material": 127
   "Draw by stalemate": 5
   "Loss: Black mates": 199
   "Loss: White mates": 214
   "No result": 12
   "Win: Black mates": 157
   "Win: White mates": 147
```