### PR TITLE
Switch to simpler futility pruning formula (14 +/- 10.9)

### DIFF
--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -25,7 +25,8 @@ pub struct SearchParams {
 
     // Futility pruning
     pub fp_threshold: usize,
-    pub fp_margins: [Score; 9],
+    pub fp_base: Score,
+    pub fp_margin: Score,
 
     // Reverse futility pruning
     pub rfp_threshold: usize,
@@ -57,7 +58,8 @@ impl Default for SearchParams {
 
             // Futility pruning
             fp_threshold: FP_THRESHOLD,
-            fp_margins: FP_MARGINS,
+            fp_base: FP_BASE,
+            fp_margin: FP_MARGIN,
 
             // Reverse futility pruning
             rfp_threshold: RFP_THRESHOLD,
@@ -97,7 +99,8 @@ pub const ASPIRATION_MAX_WINDOW: Score = 521;
 
 // Futility pruning
 pub const FP_THRESHOLD: usize = 8;
-pub const FP_MARGINS: [Score; 9] = [0, 103, 160, 226, 276, 336, 402, 462, 520];
+pub const FP_BASE: i32 = 77;
+pub const FP_MARGIN: i32 = 86;
 
 // Reverse futility pruning
 pub const RFP_THRESHOLD: usize = 6;

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -23,7 +23,6 @@ use crate::search::params::ASPIRATION_MAX_WINDOW;
 use crate::search::params::ASPIRATION_MIN_DEPTH;
 use crate::search::params::DEFAULT_TT_SIZE;
 use crate::search::params::DELTA_PRUNING_MARGIN;
-use crate::search::params::FP_MARGINS;
 use crate::search::params::FP_THRESHOLD;
 use crate::search::params::LMP_THRESHOLD;
 use crate::search::params::LMR_MIN_DEPTH;
@@ -67,7 +66,7 @@ pub struct SearchController {
     search_params: SearchParams,
 }
 
-const UCI_OPTIONS: [UciOption; 22] = [
+const UCI_OPTIONS: [UciOption; 13] = [
     UciOption { 
         name: "Hash",
         option_type: OptionType::Spin { 
@@ -127,87 +126,6 @@ const UCI_OPTIONS: [UciOption; 22] = [
             min: 2,
             max: 12,
             default: FP_THRESHOLD as i32,
-        }
-    },
-
-    UciOption {
-        name: "fp_margins0",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 900,
-            default: FP_MARGINS[0]
-        }
-    },
-
-    UciOption {
-        name: "fp_margins1",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 900,
-            default: FP_MARGINS[1]
-        }
-    },
-
-    UciOption {
-        name: "fp_margins2",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 900,
-            default: FP_MARGINS[2]
-        }
-    },
-
-    UciOption {
-        name: "fp_margins3",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 900,
-            default: FP_MARGINS[3]
-        }
-    },
-
-    UciOption {
-        name: "fp_margins4",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 900,
-            default: FP_MARGINS[4]
-        }
-    },
-
-    UciOption {
-        name: "fp_margins5",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 900,
-            default: FP_MARGINS[5]
-        }
-    },
-
-    UciOption {
-        name: "fp_margins6",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 900,
-            default: FP_MARGINS[6]
-        }
-    },
-
-    UciOption {
-        name: "fp_margins7",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 900,
-            default: FP_MARGINS[7]
-        }
-    },
-
-    UciOption {
-        name: "fp_margins8",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 900,
-            default: FP_MARGINS[8]
         }
     },
 
@@ -416,60 +334,6 @@ impl SearchController {
                                 "fp_threshold" => {
                                     let value: usize = value.parse()?;
                                     self.search_params.fp_threshold = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "fp_margins0" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.fp_margins[0] = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "fp_margins1" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.fp_margins[1] = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "fp_margins2" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.fp_margins[2] = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "fp_margins3" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.fp_margins[3] = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "fp_margins4" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.fp_margins[4] = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "fp_margins5" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.fp_margins[5] = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "fp_margins6" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.fp_margins[6] = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "fp_margins7" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.fp_margins[7] = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "fp_margins8" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.fp_margins[8] = value;
                                     self.search_thread.set_search_params(self.search_params.clone())
                                 },
 


### PR DESCRIPTION
Same as LMP: trying to cut down the number of SPSA'able parameters.

Mostly just making sure it's not a regression, but it seems to have gained a tiny bit.

```
Score of Simbelmyne vs Simbelmyne main: 614 - 529 - 969 [0.520]
...      Simbelmyne playing White: 294 - 268 - 495  [0.512] 1057
...      Simbelmyne playing Black: 320 - 261 - 474  [0.528] 1055
...      White vs Black: 555 - 588 - 969  [0.492] 2112
Elo difference: 14.0 +/- 10.9, LOS: 99.4 %, DrawRatio: 45.9 %
SPRT: llr 0 (0.0%), lbound -inf, ubound inf
2124 of 5000 games finished.

Player: Simbelmyne
   "Draw by 3-fold repetition": 447
   "Draw by fifty moves rule": 243
   "Draw by insufficient mating material": 272
   "Draw by stalemate": 7
   "Loss: Black mates": 268
   "Loss: White mates": 261
   "No result": 12
   "Win: Black mates": 320
   "Win: White mates": 294
Player: Simbelmyne main
   "Draw by 3-fold repetition": 447
   "Draw by fifty moves rule": 243
   "Draw by insufficient mating material": 272
   "Draw by stalemate": 7
   "Loss: Black mates": 320
   "Loss: White mates": 294
   "No result": 12
   "Win: Black mates": 268
   "Win: White mates": 261
```