### PR TITLE
Only flag "one legal move" in root

### DIFF
--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -223,7 +223,7 @@ impl Position {
         }
 
         // If the move is forced, don't waste any more time on this position
-        if legal_moves.len() == 1 {
+        if in_root && legal_moves.len() == 1 {
             search.tc.stop_early();
         }
 

--- a/simbelmyne/src/time_control.rs
+++ b/simbelmyne/src/time_control.rs
@@ -142,7 +142,7 @@ impl TimeController {
         // Always respect the global stop flag
         if self.stopped() {
             return false;
-        }     
+        }
 
         // If no global stop is detected, then respect the chosen time control
         match self.tc {
@@ -169,12 +169,6 @@ impl TimeController {
             return true;
         }
 
-        // Stop early if the search signaled that there's no point searching
-        // any further.
-        if self.stop_early {
-            return false;
-        }
-
         // Always respect the global stop flag
         if self.stopped() {
             return false;
@@ -195,6 +189,12 @@ impl TimeController {
             },
 
             TimeControl::Clock { .. } => {
+                // Stop early if the search signaled that there's no point 
+                // searching any further.
+                if self.stop_early {
+                    return false;
+                }
+
                 self.elapsed() < self.soft_time
             },
 


### PR DESCRIPTION
Don't want to stop the search early because _somewhere_ in the tree, there's a forced move!

Only testing it's not too big of a regression. Happy taking my chances.

```
Score of Simbelmyne vs Simbelmyne main: 696 - 660 - 1120 [0.507]
...      Simbelmyne playing White: 351 - 327 - 560  [0.510] 1238
...      Simbelmyne playing Black: 345 - 333 - 560  [0.505] 1238
...      White vs Black: 684 - 672 - 1120  [0.502] 2476
Elo difference: 5.1 +/- 10.1, LOS: 83.6 %, DrawRatio: 45.2 %
```