### PR TITLE
Share the time controller between search iterations

### DIFF
--- a/simbelmyne/src/cli/bench.rs
+++ b/simbelmyne/src/cli/bench.rs
@@ -20,10 +20,10 @@ pub fn run_single(fen: &str, depth: usize) {
     let board = fen.parse().unwrap();
     let position = Position::new(board);
     let mut tt = TTable::with_capacity(64);
-    let (tc, _handle) = TimeController::new(TimeControl::Depth(depth), board);
+    let (mut tc, _handle) = TimeController::new(TimeControl::Depth(depth), board);
     let mut history = HistoryTable::new();
     let search_params = SearchParams::default();
-    let search = position.search::<NO_DEBUG>(&mut tt, &mut history, tc, &search_params);
+    let search = position.search::<NO_DEBUG>(&mut tt, &mut history, &mut tc, &search_params);
 
     println!("{board}");
     println!("{:17} {}", "FEN:".green(), fen);

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -56,7 +56,7 @@ pub struct Search<'a> {
     pub seldepth: usize,
 
     // The time control for the search
-    pub tc: TimeController,
+    pub tc: &'a mut TimeController,
 
     /// The set of killer moves at a given ply.
     pub killers: [Killers; MAX_DEPTH],
@@ -73,7 +73,7 @@ pub struct Search<'a> {
 
 impl<'a> Search<'a> {
     /// Create a new search
-    pub fn new(depth: usize, history_table: &'a mut HistoryTable, tc: TimeController, search_params: &'a SearchParams) -> Self {
+    pub fn new(depth: usize, history_table: &'a mut HistoryTable, tc: &'a mut TimeController, search_params: &'a SearchParams) -> Self {
         Self {
             depth,
             seldepth: 0,
@@ -96,14 +96,14 @@ impl Position {
     /// Perform an iterative-deepening search at increasing depths
     /// 
     /// Return the result from the last fully-completed iteration
-    pub fn search<const DEBUG: bool>(&self, tt: &mut TTable, history: &mut HistoryTable, tc: TimeController, search_params: &SearchParams) -> SearchReport {
+    pub fn search<const DEBUG: bool>(&self, tt: &mut TTable, history: &mut HistoryTable, tc: &mut TimeController, search_params: &SearchParams) -> SearchReport {
         let mut depth = 1;
         let mut latest_report = SearchReport::default();
         let mut pv = PVTable::new();
 
         while depth <= MAX_DEPTH && tc.should_start_search(depth) {
             pv.clear();
-            let mut search = Search::new(depth, history, tc.clone(), search_params);
+            let mut search = Search::new(depth, history, tc, search_params);
 
             let score = self.aspiration_search(
                 depth, 

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -460,10 +460,10 @@ impl SearchThread {
 
             for msg in rx.iter() {
                 match msg {
-                    SearchCommand::Search(position, tc) => {
+                    SearchCommand::Search(position, mut tc) => {
                         history.age_entries();
                         tt.increment_age();
-                        position.search::<DEBUG>(&mut tt, &mut history, tc, &search_params);
+                        position.search::<DEBUG>(&mut tt, &mut history, &mut tc, &search_params);
                     },
 
                     SearchCommand::Clear => {


### PR DESCRIPTION
This was the reason we were getting weird nodecounts and nps values