### PR TITLE
Reduce pv nodes less, rather than non-pv nodes more

### DIFF
--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -329,9 +329,6 @@ impl Position {
                     // Fetch the base LMR reduction value from the LMR table
                     reduction = lmr_reduction(depth, move_count);
 
-                    // Reduce non-pv nodes more
-                    reduction += !PV as usize;
-
                     // Reduce quiets and bad tacticals more
                     reduction += (legal_moves.stage() > Stage::GoodTacticals) as usize;
 
@@ -340,6 +337,9 @@ impl Position {
 
                     // Reduce more if the TT move is a tactical
                     reduction += tt_move.is_some_and(|mv| mv.is_tactical()) as usize;
+
+                    // Reduce non-pv nodes more
+                    reduction -= PV as usize;
 
                     // Reduce less when the current position is in check
                     reduction -= in_check as usize;


### PR DESCRIPTION
```
Score of Simbelmyne vs simbelmyne-main: 1179 - 1064 - 1713  [0.515] 3956
...      Simbelmyne playing White: 581 - 561 - 836  [0.505] 1978
...      Simbelmyne playing Black: 598 - 503 - 877  [0.524] 1978
...      White vs Black: 1084 - 1159 - 1713  [0.491] 3956
Elo difference: 10.1 +/- 8.1, LOS: 99.2 %, DrawRatio: 43.3 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted

Player: Simbelmyne
   "Draw by 3-fold repetition": 333
   "Draw by fifty moves rule": 183
   "Draw by insufficient mating material": 1164
   "Draw by stalemate": 33
   "Loss: Black mates": 561
   "Loss: White mates": 503
   "No result": 11
   "Win: Black mates": 598
   "Win: White mates": 581
Player: simbelmyne-main
   "Draw by 3-fold repetition": 333
   "Draw by fifty moves rule": 183
   "Draw by insufficient mating material": 1164
   "Draw by stalemate": 33
   "Loss: Black mates": 598
   "Loss: White mates": 581
   "No result": 11
   "Win: Black mates": 561
   "Win: White mates": 503
```