### PR TITLE
History refactor, pt2

### DIFF
--- a/simbelmyne/src/history_tables/history.rs
+++ b/simbelmyne/src/history_tables/history.rs
@@ -177,3 +177,14 @@ impl SubAssign for HistoryScore {
     }
 }
 
+impl From<HistoryScore> for i16 {
+    fn from(value: HistoryScore) -> Self {
+        value.0
+    }
+}
+
+impl From<HistoryScore> for i32 {
+    fn from(value: HistoryScore) -> Self {
+        value.0 as i32
+    }
+}

--- a/simbelmyne/src/history_tables/history.rs
+++ b/simbelmyne/src/history_tables/history.rs
@@ -42,16 +42,6 @@ impl HistoryTable {
         }
     }
 
-    /// Set the score for a particular move and piece
-    pub fn set(&mut self, mv: &Move, piece: Piece, value: i16) {
-        self.scores[piece as usize][mv.tgt() as usize] = HistoryScore(value);
-    }
-
-    /// Get the score for a particular move and piece
-    pub fn get(&self, mv: &Move, piece: Piece) -> i16 {
-        self.scores[piece as usize][mv.tgt() as usize].0
-    }
-
     /// Reduce the values from previous searches so they don't swamp this 
     /// search's history values.
     pub fn age_entries(&mut self) {
@@ -102,7 +92,6 @@ impl Default for HistoryIndex {
         Self(Square::A1, Piece::WP)
     }
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -34,6 +34,7 @@ use chess::movegen::legal_moves::MAX_MOVES;
 use chess::movegen::legal_moves::MoveList;
 use chess::movegen::moves::Move;
 use chess::piece::PieceType;
+use crate::history_tables::history::HistoryIndex;
 use crate::history_tables::history::HistoryTable;
 use crate::history_tables::killers::Killers;
 use crate::position::Position;
@@ -266,8 +267,8 @@ impl<'pos> MovePicker<'pos> {
                 self.scores[i] += KILLER_BONUS;
             } 
 
-            let piece = self.position.board.get_at(mv.src()).unwrap();
-            self.scores[i] += history_table.get(mv, piece) as i32;
+            let idx = HistoryIndex::new(&self.position.board, *mv);
+            self.scores[i] += i32::from(history_table[idx]);
         }
     }
 }


### PR DESCRIPTION
Jumped the gun a bit. Adds a last couple of touches and simplifications: use direct indexing everywhere (including in move picker), adds some more utility traits for converting between HistoryScore and integer types.