### PR TITLE
Simplify history penalties and ageing (35.9 +/- 20.1)

### DIFF
--- a/simbelmyne/src/history_tables/history.rs
+++ b/simbelmyne/src/history_tables/history.rs
@@ -114,10 +114,8 @@ impl HistoryScore {
     }
 
     /// Compute the appropriate history penalty for a given depth
-    /// TODO: Should this really be smaller than the bonus?
     pub fn penalty(depth: usize) -> Self {
-        let bonus = Self::bonus(depth);
-        Self(bonus.0 / 8)
+        Self::bonus(depth)
     }
 }
 

--- a/simbelmyne/src/history_tables/history.rs
+++ b/simbelmyne/src/history_tables/history.rs
@@ -112,11 +112,6 @@ impl HistoryScore {
 
         Self(bonus)
     }
-
-    /// Compute the appropriate history penalty for a given depth
-    pub fn penalty(depth: usize) -> Self {
-        Self::bonus(depth)
-    }
 }
 
 impl Neg for HistoryScore {

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -433,15 +433,16 @@ impl Position {
 
         // If we had a cutoff, update the Killers and History
         if node_type == NodeType::Lower && best_move.is_quiet() {
+            let bonus = HistoryScore::bonus(depth);
+
             // Add bonus to history score for the fail-high move
             let idx = HistoryIndex::new(&self.board, best_move);
-            search.history_table[idx] += HistoryScore::bonus(depth);
+            search.history_table[idx] += bonus;
 
             // Deduct penalty for all tried quiets that didn't fail high
-            let penalty = HistoryScore::penalty(depth);
             for mv in quiets_tried {
                 let idx = HistoryIndex::new(&self.board, mv);
-                search.history_table[idx] -= penalty;
+                search.history_table[idx] -= bonus;
             }
 
             search.killers[ply].add(best_move);

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -116,7 +116,7 @@ pub const RFP_MARGIN: Score = 47;
 pub const MAX_KILLERS: usize = 2;
 
 // History table
-pub const HIST_AGE_DIVISOR: i16 = 4;
+pub const HIST_AGE_DIVISOR: i16 = 2;
 
 ////////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
Pretty big difference, all of a sudden.

I'm almost tempted to try history-based LMR again real quick to see if it gains now.

```
Score of Simbelmyne vs simbelmyne-main: 242 - 171 - 276  [0.552] 689
...      Simbelmyne playing White: 120 - 80 - 145  [0.558] 345
...      Simbelmyne playing Black: 122 - 91 - 131  [0.545] 344
...      White vs Black: 211 - 202 - 276  [0.507] 689
Elo difference: 35.9 +/- 20.1, LOS: 100.0 %, DrawRatio: 40.1 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted

Player: Simbelmyne
   "Draw by 3-fold repetition": 48
   "Draw by fifty moves rule": 31
   "Draw by insufficient mating material": 191
   "Draw by stalemate": 6
   "Loss: Black mates": 80
   "Loss: White mates": 91
   "No result": 11
   "Win: Black mates": 122
   "Win: White mates": 120
Player: simbelmyne-main
   "Draw by 3-fold repetition": 48
   "Draw by fifty moves rule": 31
   "Draw by insufficient mating material": 191
   "Draw by stalemate": 6
   "Loss: Black mates": 122
   "Loss: White mates": 120
   "No result": 11
   "Win: Black mates": 80
   "Win: White mates": 91
```