### PR TITLE
1ply continuation history (21.6 +/- 14.6)

### DIFF
--- a/simbelmyne/src/cli/bench.rs
+++ b/simbelmyne/src/cli/bench.rs
@@ -1,6 +1,7 @@
 use colored::Colorize;
 use uci::time_control::TimeControl;
 
+use crate::history_tables::conthist::ContHist;
 use crate::history_tables::history::HistoryTable;
 use crate::position::Position;
 use crate::transpositions::TTable;
@@ -26,8 +27,16 @@ pub fn run_single(fen: &str, depth: usize) {
     let mut tt = TTable::with_capacity(64);
     let (mut tc, _handle) = TimeController::new(TimeControl::Depth(depth), board);
     let mut history = HistoryTable::new();
+    let mut conthist = ContHist::boxed();
+
     let search_params = SearchParams::default();
-    let search = position.search::<NO_DEBUG>(&mut tt, &mut history, &mut tc, &search_params);
+    let search = position.search::<NO_DEBUG>(
+        &mut tt, 
+        &mut history, 
+        &mut conthist,
+        &mut tc, 
+        &search_params
+    );
 
     println!("{board}");
     println!("{:17} {}", "FEN:".green(), fen);

--- a/simbelmyne/src/history_tables/conthist.rs
+++ b/simbelmyne/src/history_tables/conthist.rs
@@ -1,0 +1,43 @@
+/// Continuation history table
+///
+///
+use std::ops::{Index, IndexMut};
+use chess::{piece::Piece, square::Square};
+use super::history::{HistoryIndex, HistoryTable};
+
+#[derive(Debug)]
+pub struct ContHist {
+    table: [[HistoryTable; Square::COUNT]; Piece::COUNT]
+}
+
+impl ContHist {
+    pub fn boxed() -> Box<Self> {
+        #![allow(clippy::cast_ptr_alignment)]
+        // SAFETY: we're allocating a zeroed block of memory, and then casting 
+        // it to a Box<Self>. This is fine! 
+        // [[HistoryTable; Square::COUNT]; Piece::COUNT] is just a bunch of i16s
+        // in disguise, which are fine to zero-out.
+        unsafe {
+            let layout = std::alloc::Layout::new::<Self>();
+            let ptr = std::alloc::alloc_zeroed(layout);
+            if ptr.is_null() {
+                std::alloc::handle_alloc_error(layout);
+            }
+            Box::from_raw(ptr.cast())
+        }
+    }
+}
+
+impl Index<HistoryIndex> for ContHist {
+    type Output = HistoryTable;
+
+    fn index(&self, index: HistoryIndex) -> &Self::Output {
+        &self.table[index.1 as usize][index.0 as usize]
+    }
+}
+
+impl IndexMut<HistoryIndex> for ContHist {
+    fn index_mut(&mut self, index: HistoryIndex) -> &mut Self::Output {
+        &mut self.table[index.1 as usize][index.0 as usize]
+    }
+}

--- a/simbelmyne/src/history_tables/history.rs
+++ b/simbelmyne/src/history_tables/history.rs
@@ -76,7 +76,7 @@ impl IndexMut<HistoryIndex> for HistoryTable {
 /// A History index is a convenient wrapper used to index into a History table,
 /// comprising of a Piece and a destination Square
 #[derive(Debug, Copy, Clone)]
-pub struct HistoryIndex(Square, Piece);
+pub struct HistoryIndex(pub(super) Square, pub(super) Piece);
 
 impl HistoryIndex {
     pub fn new(board: &Board, mv: Move) -> Self {

--- a/simbelmyne/src/history_tables/mod.rs
+++ b/simbelmyne/src/history_tables/mod.rs
@@ -1,3 +1,4 @@
 pub mod history;
+pub mod conthist;
 pub mod killers;
 pub mod pv;

--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -259,7 +259,7 @@ impl<'pos> MovePicker<'pos> {
     }
 
     /// Score quiet moves according to the killer move and history tables
-    fn score_quiets(&mut self, history_table: &HistoryTable) {
+    fn score_quiets(&mut self, history_table: &HistoryTable, conthist: Option<&HistoryTable>) {
         for i in self.quiet_index..self.bad_tactical_index {
             let mv = &self.moves[i];
 
@@ -269,6 +269,10 @@ impl<'pos> MovePicker<'pos> {
 
             let idx = HistoryIndex::new(&self.position.board, *mv);
             self.scores[i] += i32::from(history_table[idx]);
+
+            if let Some(conthist) = conthist.as_ref() {
+                self.scores[i] += i32::from(conthist[idx]);
+            }
         }
     }
 }
@@ -277,7 +281,7 @@ impl<'pos> MovePicker<'pos> {
 //     type Item = Move;
 
 impl<'a> MovePicker<'a> {
-    pub fn next(&mut self, history: &HistoryTable) -> Option<Move> {
+    pub fn next(&mut self, history: &HistoryTable, conthist: Option<&HistoryTable>) -> Option<Move> {
 
         // Check if we've reached the end of the move list
         if self.stage == Stage::Done {
@@ -346,7 +350,7 @@ impl<'a> MovePicker<'a> {
         ////////////////////////////////////////////////////////////////////////
 
         if self.stage == Stage::ScoreQuiets {
-            self.score_quiets(history);
+            self.score_quiets(history, conthist);
             self.stage = Stage::Quiets;
         }
 
@@ -423,7 +427,7 @@ mod tests {
 
         picker.only_good_tacticals = true;
 
-        while let Some(mv) = picker.next(&history) {
+        while let Some(mv) = picker.next(&history, None) {
             println!("Yielded {mv}");
         }
     }

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -13,6 +13,7 @@ use chess::movegen::legal_moves::MoveList;
 use chess::movegen::moves::Move;
 
 use super::params::lmr_reduction;
+use super::HistoryIndex;
 use super::Search;
 use super::params::IIR_THRESHOLD;
 use super::params::MAX_DEPTH;
@@ -301,6 +302,7 @@ impl Position {
             ////////////////////////////////////////////////////////////////////
 
             let mut score;
+            search.stack[ply].history_index = HistoryIndex::new(&self.board, mv);
             let next_position = self.play_move(mv);
 
             // Instruct the CPU to load the TT entry into the cache ahead of time

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -13,7 +13,6 @@ use chess::movegen::legal_moves::MoveList;
 use chess::movegen::moves::Move;
 
 use super::params::lmr_reduction;
-use super::HistoryIndex;
 use super::Search;
 use super::params::IIR_THRESHOLD;
 use super::params::MAX_DEPTH;

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -126,7 +126,7 @@ impl Position {
             return -Score::MATE + ply as Score;
         }
 
-       while let Some(mv) = tacticals.next(&search.history_table) {
+       while let Some(mv) = tacticals.next(&search.history_table, None) {
             ////////////////////////////////////////////////////////////////////
             //
             // Delta/Futility pruning

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -10,6 +10,7 @@ use crate::transpositions::NodeType;
 use crate::transpositions::TTEntry;
 use crate::transpositions::TTable;
 use super::params::MAX_DEPTH;
+use super::HistoryIndex;
 use super::Search;
 
 // Constants used for more readable const generics
@@ -158,6 +159,7 @@ impl Position {
             // Play the move and recurse down the tree
             //
             ////////////////////////////////////////////////////////////////////
+            search.stack[ply].history_index = HistoryIndex::new(&self.board, mv);
             let next_position = self.play_move(mv);
             tt.prefetch(next_position.hash);
 

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -18,6 +18,7 @@ use uci::options::OptionType;
 use uci::options::UciOption;
 use crate::evaluate::pretty_print::print_eval;
 use crate::evaluate::Score;
+use crate::history_tables::conthist::ContHist;
 use crate::history_tables::history::HistoryTable;
 use crate::search::params::ASPIRATION_BASE_WINDOW;
 use crate::search::params::ASPIRATION_MAX_WINDOW;
@@ -456,6 +457,7 @@ impl SearchThread {
             let mut tt_size = DEFAULT_TT_SIZE;
             let mut tt = TTable::with_capacity(tt_size);
             let mut history = HistoryTable::new();
+            let mut conthist = ContHist::boxed();
             let mut search_params = SearchParams::default();
 
             for msg in rx.iter() {
@@ -463,7 +465,13 @@ impl SearchThread {
                     SearchCommand::Search(position, mut tc) => {
                         history.age_entries();
                         tt.increment_age();
-                        position.search::<DEBUG>(&mut tt, &mut history, &mut tc, &search_params);
+                        position.search::<DEBUG>(
+                            &mut tt, 
+                            &mut history, 
+                            &mut conthist,
+                            &mut tc, 
+                            &search_params
+                        );
                     },
 
                     SearchCommand::Clear => {


### PR DESCRIPTION
```
Score of Simbelmyne vs simbelmyne-main: 425 - 345 - 521  [0.531] 1291
...      Simbelmyne playing White: 226 - 169 - 251  [0.544] 646
...      Simbelmyne playing Black: 199 - 176 - 270  [0.518] 645
...      White vs Black: 402 - 368 - 521  [0.513] 1291
Elo difference: 21.6 +/- 14.6, LOS: 99.8 %, DrawRatio: 40.4 %
SPRT: llr 2.97 (101.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```

😎