### PR TITLE
Add countermoves to history (13.4 +/- 10.4)

### DIFF
--- a/simbelmyne/src/history_tables/countermoves.rs
+++ b/simbelmyne/src/history_tables/countermoves.rs
@@ -1,0 +1,54 @@
+use std::ops::{Index, IndexMut};
+
+/// Countermove table
+///
+/// The countermove table, similar to the killers table, stores quiet moves that
+/// produced a beta-cutoff. Where the Killers table will store them by ply (and,
+/// hence, not super local), the countermove table stores them by _the previously
+/// played move_. (Get it? Countermove?)
+///
+/// We only store a single countermove, and play it right after the killer moves.
+
+use chess::movegen::moves::Move;
+use chess::piece::Piece;
+use chess::square::Square;
+
+use super::history::HistoryIndex;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct CountermoveTable {
+    scores: [[Option<Move>; Square::COUNT]; Piece::COUNT]
+}
+
+impl CountermoveTable {
+    /// Create a new CountermoveTable on the heap
+    pub fn boxed() -> Box<Self> {
+        #![allow(clippy::cast_ptr_alignment)]
+        // SAFETY: we're allocating a zeroed block of memory, and then casting 
+        // it to a Box<Self>. This is fine! 
+        // [[HistoryTable; Square::COUNT]; Piece::COUNT] is just a bunch of i16s
+        // in disguise, which are fine to zero-out.
+        unsafe {
+            let layout = std::alloc::Layout::new::<Self>();
+            let ptr = std::alloc::alloc_zeroed(layout);
+            if ptr.is_null() {
+                std::alloc::handle_alloc_error(layout);
+            }
+            Box::from_raw(ptr.cast())
+        }
+    }
+}
+
+impl Index<HistoryIndex> for CountermoveTable {
+    type Output = Option<Move>;
+
+    fn index(&self, index: HistoryIndex) -> &Self::Output {
+        &self.scores[index.1 as usize][index.0 as usize]
+    }
+}
+
+impl IndexMut<HistoryIndex> for CountermoveTable {
+    fn index_mut(&mut self, index: HistoryIndex) -> &mut Self::Output {
+        &mut self.scores[index.1 as usize][index.0 as usize]
+    }
+}

--- a/simbelmyne/src/history_tables/mod.rs
+++ b/simbelmyne/src/history_tables/mod.rs
@@ -1,4 +1,5 @@
 pub mod history;
 pub mod conthist;
 pub mod killers;
+pub mod countermoves;
 pub mod pv;

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -24,6 +24,7 @@
 use std::time::Duration;
 use crate::evaluate::ScoreExt;
 use crate::history_tables::conthist::ContHist;
+use crate::history_tables::countermoves::CountermoveTable;
 use crate::history_tables::history::HistoryIndex;
 use crate::history_tables::history::HistoryTable;
 use crate::history_tables::killers::Killers;
@@ -74,6 +75,9 @@ pub struct Search<'a> {
     /// The set of killer moves at a given ply.
     pub killers: [Killers; MAX_DEPTH],
 
+    /// The countermove table
+    pub countermoves: Box<CountermoveTable>,
+
     /// Main history table
     pub history_table: &'a mut HistoryTable,
 
@@ -96,6 +100,7 @@ impl<'a> Search<'a> {
             seldepth: 0,
             tc,
             killers: [Killers::new(); MAX_DEPTH],
+            countermoves: CountermoveTable::boxed(),
             history_table,
             conthist_table,
             search_params,

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -110,6 +110,7 @@ impl Position {
             self.board.legal_moves::<CAPTURES>(),
             tt_move,
             Killers::new(),
+            None,
         );
 
         tacticals.only_good_tacticals = true;


### PR DESCRIPTION
```
Score of Simbelmyne vs simbelmyne-main: 776 - 680 - 1039  [0.519] 2495
...      Simbelmyne playing White: 380 - 352 - 516  [0.511] 1248
...      Simbelmyne playing Black: 396 - 328 - 523  [0.527] 1247
...      White vs Black: 708 - 748 - 1039  [0.492] 2495
Elo difference: 13.4 +/- 10.4, LOS: 99.4 %, DrawRatio: 41.6 %
SPRT: llr 2.97 (100.8%), lbound -2.94, ubound 2.94 - H1 was accepted
```