### PR TITLE
Don't overwrite TT move in fail-low nodes

### DIFF
--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -190,7 +190,7 @@ impl Position {
         //
         ////////////////////////////////////////////////////////////////////////
 
-        if tt_entry.is_none() && !in_root && depth >= IIR_THRESHOLD {
+        if tt_move.is_none() && !in_root && depth >= IIR_THRESHOLD {
             depth -= 1;
         }
 

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -73,12 +73,6 @@ impl Position {
 
         search.tc.add_node();
 
-        let mut best_move = Move::NULL;
-        let mut best_score = Score::MINUS_INF;
-        let mut node_type = NodeType::Upper;
-        let mut alpha = alpha;
-        let mut local_pv = PVTable::new();
-
         // Do all the static evaluations first
         // That is, Check whether we can/should assign a score to this node
         // without recursing any deeper.
@@ -102,7 +96,7 @@ impl Position {
         ////////////////////////////////////////////////////////////////////////
 
         let tt_entry = tt.probe(self.hash);
-        let tt_move = tt_entry.map(|entry| entry.get_move());
+        let tt_move = tt_entry.and_then(|entry| entry.get_move());
 
         if !PV && !in_root && tt_entry.is_some() {
             let tt_entry = tt_entry.unwrap();
@@ -243,6 +237,12 @@ impl Position {
 
         let mut move_count = 0;
         let mut quiets_tried = MoveList::new();
+        let mut best_move = tt_move;
+        let mut best_score = Score::MINUS_INF;
+        let mut node_type = NodeType::Upper;
+        let mut alpha = alpha;
+        let mut local_pv = PVTable::new();
+
 
         let conthist = prev_hist_idx
             .map(|prev_idx| search.conthist_table[prev_idx]);
@@ -406,7 +406,6 @@ impl Position {
 
             if score > best_score {
                 best_score = score;
-                best_move = mv;
             }
 
             if score < alpha && mv.is_quiet() {
@@ -416,12 +415,14 @@ impl Position {
 
             if score >= beta {
                 node_type = NodeType::Lower;
+                best_move = Some(mv);
                 break;
             }
 
             if score > alpha {
                 alpha = score;
                 node_type = NodeType::Exact;
+                best_move = Some(mv);
                 pv.add_to_front(mv, &local_pv);
             }
 
@@ -444,13 +445,13 @@ impl Position {
         //
         ////////////////////////////////////////////////////////////////////////
 
-        if node_type == NodeType::Lower && best_move.is_quiet() {
+        if node_type == NodeType::Lower && best_move.unwrap().is_quiet() {
+            let best_move = best_move.unwrap();
             let bonus = HistoryScore::bonus(depth);
 
             let idx = HistoryIndex::new(&self.board, best_move);
             let prev_idx = ply.checked_sub(1)
                 .map(|prev_ply| search.stack[prev_ply].history_index);
-
 
             // If there is a conthist index, update the regular history,
             // the continuation history and countermove table
@@ -494,7 +495,7 @@ impl Position {
 
         tt.insert(TTEntry::new(
             self.hash,
-            best_move,
+            best_move.unwrap_or(Move::NULL),
             best_score,
             eval,
             depth,
@@ -506,5 +507,3 @@ impl Position {
         best_score
     }
 }
-
-

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -103,7 +103,7 @@ impl Position {
         //
         ////////////////////////////////////////////////////////////////////////
 
-        let tt_move = tt_entry.map(|entry| entry.get_move());
+        let tt_move = tt_entry.and_then(|entry| entry.get_move());
 
         let mut tacticals = MovePicker::new(
             &self,
@@ -115,7 +115,7 @@ impl Position {
 
         tacticals.only_good_tacticals = true;
 
-        let mut best_move = Move::NULL;
+        let mut best_move = tt_move;
         let mut best_score = eval;
         let mut node_type = NodeType::Upper;
 
@@ -175,16 +175,17 @@ impl Position {
 
             if score > best_score {
                 best_score = score;
-                best_move = mv;
             }
 
             if score >= beta {
                 node_type = NodeType::Lower;
+                best_move = Some(mv);
                 break;
             }
 
             if score > alpha {
                 alpha = score;
+                best_move = Some(mv);
                 node_type = NodeType::Exact;
             }
 
@@ -205,7 +206,7 @@ impl Position {
         // Store in the TT
         tt.insert(TTEntry::new(
             self.hash,
-            best_move,
+            best_move.unwrap_or(Move::NULL),
             best_score,
             eval,
             0,

--- a/simbelmyne/src/transpositions.rs
+++ b/simbelmyne/src/transpositions.rs
@@ -107,8 +107,11 @@ impl TTEntry {
     }
 
     /// Return the best move for the entry
-    pub fn get_move(&self) -> Move {
-        self.best_move
+    pub fn get_move(&self) -> Option<Move> {
+        match self.best_move {
+            Move::NULL => None,
+            mv => Some(mv)
+        }
     }
 
     /// Return the score for the entry. In case of a mate score, this value is
@@ -234,11 +237,6 @@ impl TTable {
         use NodeType::*;
         let key: ZKey = ZKey::from_hash(entry.hash, self.size);
         let existing = self.table[key.0];
-
-        // Don't replace if the recieved entry has a null move
-        if !existing.is_empty() && entry.get_move() == Move::NULL {
-            return;
-        }
 
         if existing.is_empty() {
             self.table[key.0] = entry;


### PR DESCRIPTION
The reasoning is that, because the scores we get back in a fail-low node are all upper bounds, we don't _actually_ get any valuable information on which move is better. (unlike fail-high and pv nodes).

```
Score of Simbelmyne vs simbelmyne-main: 413 - 334 - 523  [0.531] 1270
...      Simbelmyne playing White: 209 - 171 - 254  [0.530] 634
...      Simbelmyne playing Black: 204 - 163 - 269  [0.532] 636
...      White vs Black: 372 - 375 - 523  [0.499] 1270
Elo difference: 21.6 +/- 14.7, LOS: 99.8 %, DrawRatio: 41.2 %
SPRT: llr 2.98 (101.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```