### PR TITLE
Include promotions in tacticals

### DIFF
--- a/chess/src/board.rs
+++ b/chess/src/board.rs
@@ -4,7 +4,7 @@
 //! it doesn't keep track of history-related things, such as repetitions and the
 //! like)
 
-use crate::constants::{LIGHT_SQUARES, DARK_SQUARES};
+use crate::constants::{DARK_SQUARES, LIGHT_SQUARES, RANKS};
 use crate::square::Square;
 use crate::bitboard::Bitboard;
 use crate::movegen::lookups::BETWEEN;
@@ -176,6 +176,14 @@ impl Board {
 
     pub fn get_checkers(&self, us: Color) -> Bitboard {
         self.checkers[us as usize]
+    }
+
+    pub fn get_promo_rank(&self) -> Bitboard {
+        if self.current.is_white() {
+            RANKS[7]
+        } else {
+            RANKS[0]
+        }
     }
 }
 


### PR DESCRIPTION
Doesn't seem to have made a difference. I guess it only really matters in vary rare cases (qsearch, or when the promotion is so far down the list of quiets that it's pruned away by LMP)

```
Score of Simbelmyne vs simbelmyne-main: 2121 - 2078 - 2979  [0.503] 7178
...      Simbelmyne playing White: 1072 - 1009 - 1509  [0.509] 3590
...      Simbelmyne playing Black: 1049 - 1069 - 1470  [0.497] 3588
...      White vs Black: 2141 - 2058 - 2979  [0.506] 7178
Elo difference: 2.1 +/- 6.1, LOS: 74.7 %, DrawRatio: 41.5 %
SPRT: llr -2.97 (-100.8%), lbound -2.94, ubound 2.94 - H0 was accepted
```