### PR TITLE
Search/improving lmp

### DIFF
--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -268,9 +268,16 @@ impl ScoreUciExt for Score {
 //
 // Search Stack Entry
 //
+// Keep track of search information about a given ply that we want to share
+// between plies.
+//
 ////////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug, Copy, Clone, Default)]
 struct SearchStackEntry {
+    /// The last index for this ply that can be used to index into history tables
     pub history_index: HistoryIndex,
+
+    /// The eval for the last position in this ply
+    pub eval: Score,
 }

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -308,8 +308,8 @@ impl Position {
             //
             ////////////////////////////////////////////////////////////////////
 
-            let lmp_moves = search.search_params.lmp_base 
-                + search.search_params.lmp_factor * depth * depth;
+            let lmp_moves = (search.search_params.lmp_base 
+                + search.search_params.lmp_factor * depth * depth) / (1 + !improving as usize);
 
             if depth <= search.search_params.lmp_threshold
                 && !PV

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -129,13 +129,16 @@ impl Position {
         // Improving heuristic:
         //
         // If our eval is better than two plies ago, we can
-        // 1. More aggressively prune fail-high based pruning/reductions (rfp, etc...)
+        // 1. More aggressively prune fail-high based pruning/reductions (rfp, 
+        //    nmp, etc...)
         // 2. Be more cautious with fail-low based pruning/reductions 
-        // (alpha-based reductions, etc...)
+        //    (fp, alpha-based reductions, etc...)
         //
         ////////////////////////////////////////////////////////////////////////
 
-        let improving = ply >= 2 && search.stack[ply - 2].eval > eval;
+        let improving = !in_check 
+            && ply >= 2 
+            && search.stack[ply - 2].eval < eval;
 
         ////////////////////////////////////////////////////////////////////////
         //

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -121,6 +121,22 @@ impl Position {
             self.score.total(&self.board)
         };
 
+        // Store the eval in the search stack
+        search.stack[ply].eval = eval;
+
+        ////////////////////////////////////////////////////////////////////////
+        //
+        // Improving heuristic:
+        //
+        // If our eval is better than two plies ago, we can
+        // 1. More aggressively prune fail-high based pruning/reductions (rfp, etc...)
+        // 2. Be more cautious with fail-low based pruning/reductions 
+        // (alpha-based reductions, etc...)
+        //
+        ////////////////////////////////////////////////////////////////////////
+
+        let improving = ply >= 2 && search.stack[ply - 2].eval > eval;
+
         ////////////////////////////////////////////////////////////////////////
         //
         // Reverse futility pruning


### PR DESCRIPTION
```
Score of Simbelmyne vs simbelmyne-main: 523 - 438 - 613  [0.527] 1574
...      Simbelmyne playing White: 274 - 207 - 307  [0.543] 788
...      Simbelmyne playing Black: 249 - 231 - 306  [0.511] 786
...      White vs Black: 505 - 456 - 613  [0.516] 1574
Elo difference: 18.8 +/- 13.4, LOS: 99.7 %, DrawRatio: 38.9 %
SPRT: llr 2.95 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```