### PR TITLE
Use improving in NMP

### DIFF
--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -176,6 +176,7 @@ impl Position {
             && !PV
             && !in_root
             && !in_check
+            && eval + search.search_params.nmp_improving_margin * improving as Score >= beta
             && self.board.zugzwang_unlikely();
 
         if should_null_prune {

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -17,6 +17,7 @@ pub struct SearchParams {
     // Null move pruning
     pub nmp_base_reduction: usize,
     pub nmp_reduction_factor: usize,
+    pub nmp_improving_margin: Score,
 
     // Aspiration windows
     pub aspiration_min_depth: usize,
@@ -50,6 +51,7 @@ impl Default for SearchParams {
             // Null move pruning
             nmp_base_reduction: NMP_BASE_REDUCTION,
             nmp_reduction_factor: NMP_REDUCTION_FACTOR,
+            nmp_improving_margin: NMP_IMPROVING_MARGIN,
 
             // Aspiration windows
             aspiration_min_depth: ASPIRATION_MIN_DEPTH,
@@ -91,6 +93,7 @@ pub const MAX_DEPTH: usize = 128;
 // Null-move pruning
 pub const NMP_BASE_REDUCTION: usize = 4;
 pub const NMP_REDUCTION_FACTOR: usize = 4;
+pub const NMP_IMPROVING_MARGIN: Score = 70;
 
 // Aspiration search
 pub const ASPIRATION_MIN_DEPTH: usize = 7;

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -34,6 +34,7 @@ use crate::search::params::LMP_THRESHOLD;
 use crate::search::params::LMR_MIN_DEPTH;
 use crate::search::params::LMR_THRESHOLD;
 use crate::search::params::NMP_BASE_REDUCTION;
+use crate::search::params::NMP_IMPROVING_MARGIN;
 use crate::search::params::NMP_REDUCTION_FACTOR;
 use crate::search::params::RFP_MARGIN;
 use crate::search::params::RFP_THRESHOLD;
@@ -71,7 +72,7 @@ pub struct SearchController {
     search_params: SearchParams,
 }
 
-const UCI_OPTIONS: [UciOption; 17] = [
+const UCI_OPTIONS: [UciOption; 18] = [
     UciOption { 
         name: "Hash",
         option_type: OptionType::Spin { 
@@ -96,6 +97,15 @@ const UCI_OPTIONS: [UciOption; 17] = [
             min: 0,
             max: 8,
             default: NMP_REDUCTION_FACTOR as i32, 
+        }
+    },
+
+    UciOption { 
+        name: "nmp_improving_margin",
+        option_type: OptionType::Spin {
+            min: 0,
+            max: 150,
+            default: NMP_IMPROVING_MARGIN as i32, 
         }
     },
 
@@ -351,6 +361,12 @@ impl SearchController {
                                 "nmp_reduction_factor" => {
                                     let value: usize = value.parse()?;
                                     self.search_params.nmp_reduction_factor = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "nmp_improving_margin" => {
+                                    let value: Score = value.parse()?;
+                                    self.search_params.nmp_improving_margin = value;
                                     self.search_thread.set_search_params(self.search_params.clone())
                                 },
 


### PR DESCRIPTION
```
Score of Simbelmyne vs simbelmyne-main: 1517 - 1361 - 2005  [0.516] 4883
...      Simbelmyne playing White: 741 - 649 - 1052  [0.519] 2442
...      Simbelmyne playing Black: 776 - 712 - 953  [0.513] 2441
...      White vs Black: 1453 - 1425 - 2005  [0.503] 4883
Elo difference: 11.1 +/- 7.5, LOS: 99.8 %, DrawRatio: 41.1 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
```