### PR TITLE
Prune less/more according to history score

### DIFF
--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -145,6 +145,10 @@ impl<'pos> MovePicker<'pos> {
         self.moves.len()
     }
 
+    pub fn current_score(&self) -> i32 {
+        self.scores[self.index]
+    }
+
     /// Swap moves at provided indices, and update their associated scores.
     fn swap_moves(&mut self, i: usize, j: usize) {
         self.moves.swap(i, j); 

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -379,6 +379,11 @@ impl Position {
                     // Reduce less when the move gives check
                     reduction -= next_position.board.in_check() as usize;
 
+                    // Reduce moves with good history less, with bad history more
+                    if mv.is_quiet() {
+                        reduction -= (legal_moves.current_score() / 8191) as usize;
+                    }
+
                     // Make sure we don't reduce below zero
                     reduction = reduction.clamp(0, depth - 1);
                 }


### PR DESCRIPTION
```
Score of Simbelmyne vs simbelmyne-main: 567 - 481 - 739  [0.524] 1787
...      Simbelmyne playing White: 284 - 248 - 362  [0.520] 894
...      Simbelmyne playing Black: 283 - 233 - 377  [0.528] 893
...      White vs Black: 517 - 531 - 739  [0.496] 1787
Elo difference: 16.7 +/- 12.3, LOS: 99.6 %, DrawRatio: 41.4 %
SPRT: llr 2.96 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
```