### PR TITLE
Move "forced move" logic out of negamax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "simbelmyne"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -132,6 +132,10 @@ impl Position {
         let mut latest_report = SearchReport::default();
         let mut pv = PVTable::new();
 
+        if self.board.legal_moves::<true>().len() == 1 {
+            tc.stop_early();
+        }
+
         while depth <= MAX_DEPTH && tc.should_start_search(depth) {
             pv.clear();
             let mut search = Search::new(

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -244,11 +244,6 @@ impl Position {
             return self.score.draw_score(ply, search.tc.nodes());
         }
 
-        // If the move is forced, don't waste any more time on this position
-        if in_root && legal_moves.len() == 1 {
-            search.tc.stop_early();
-        }
-
         ////////////////////////////////////////////////////////////////////////
         //
         // Iterate over the remaining moves


### PR DESCRIPTION
In preparation of the lazy movepicker rewrite, we won't have easy access to the "number of moves", because we won't actually generate all of them. (e.g., it's hard to distinguish the scenarios where we play a TT move and it causes a cutoff (movepicker only knows about one move), or we've actually generated all the moves, and there's only one)

I'm seriously confused by this. How does this change make that big of a difference? Maybe double check that we didn't do an oopsie. But I don't think so?

```
Score of Simbelmyne vs simbelmyne-main: 385 - 307 - 477  [0.533] 1169
...      Simbelmyne playing White: 203 - 141 - 240  [0.553] 584
...      Simbelmyne playing Black: 182 - 166 - 237  [0.514] 585
...      White vs Black: 369 - 323 - 477  [0.520] 1169
Elo difference: 23.2 +/- 15.3, LOS: 99.8 %, DrawRatio: 40.8 %
SPRT: llr 2.99 (101.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```