### PR TITLE
Lazily yield TT Move from move picker

### DIFF
--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -112,6 +112,12 @@ impl<'pos, const ALL: bool> MovePicker<'pos, ALL> {
     ) -> MovePicker<'pos, ALL> {
         let scores = [0; MAX_MOVES];
 
+
+        // If we're only interested in tacticals, but the TT move is
+        // quiet, just clear it and forget about it.
+        let tt_move = tt_move.filter(|mv| ALL || mv.is_tactical());
+
+
         MovePicker {
             stage: Stage::TTMove,
             quiet_index: 0,
@@ -302,8 +308,9 @@ impl<'a, const ALL: bool> MovePicker<'a, ALL> {
         if self.stage == Stage::TTMove {
             self.stage = Stage::GenerateMoves;
 
-            if self.tt_move.is_some() {
-                return self.tt_move;
+
+            if let Some(tt_move) = self.tt_move {
+                return Some(tt_move)
             }
         } 
 

--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -53,6 +53,7 @@ const COUNTERMOVE_BONUS: i32 = 20000;
 #[derive(Debug, PartialEq, Eq, Copy, Clone, PartialOrd)]
 pub enum Stage {
     TTMove,
+    GenerateMoves,
     ScoreTacticals,
     GoodTacticals,
     ScoreQuiets,
@@ -63,7 +64,7 @@ pub enum Stage {
 
 /// A Move Picker is a lazy wrapper around a Vec of moves that sorts and yields
 /// moves as lazily as possible.
-pub struct MovePicker<'pos> {
+pub struct MovePicker<'pos, const ALL: bool = true> {
     /// The current stage the move picker is in
     stage: Stage,
 
@@ -102,31 +103,22 @@ pub struct MovePicker<'pos> {
     pub only_good_tacticals: bool,
 }
 
-impl<'pos> MovePicker<'pos> {
+impl<'pos, const ALL: bool> MovePicker<'pos, ALL> {
     pub fn new(
         position: &'pos Position, 
-        moves: MoveList,
         tt_move: Option<Move>,
         killers: Killers,
         countermove: Option<Move>,
-    ) -> MovePicker<'pos> {
+    ) -> MovePicker<'pos, ALL> {
         let scores = [0; MAX_MOVES];
 
-        // If the move list is empty, we're done here.
-        let initial_stage = if moves.len() == 0 { 
-            Stage::Done 
-        } else { 
-            Stage::TTMove 
-        };
-
-
         MovePicker {
-            stage: initial_stage,
+            stage: Stage::TTMove,
             quiet_index: 0,
-            bad_tactical_index: moves.len(),
+            bad_tactical_index: 0,
             position,
             scores,
-            moves,
+            moves: MoveList::new(),
             tt_move,
             index: 0,
             killers,
@@ -138,11 +130,6 @@ impl<'pos> MovePicker<'pos> {
     /// Return the stage of movegen
     pub fn stage(&self) -> Stage {
         self.stage
-    }
-
-    /// Return the number of moves stored in the move picker
-    pub fn len(&self) -> usize {
-        self.moves.len()
     }
 
     pub fn current_score(&self) -> i32 {
@@ -294,10 +281,7 @@ impl<'pos> MovePicker<'pos> {
     }
 }
 
-// impl<'pos, 'hist> Iterator for MovePicker<'pos, 'hist> {
-//     type Item = Move;
-
-impl<'a> MovePicker<'a> {
+impl<'a, const ALL: bool> MovePicker<'a, ALL> {
     pub fn next(&mut self, history: &HistoryTable, conthist: Option<&HistoryTable>) -> Option<Move> {
 
         // Check if we've reached the end of the move list
@@ -309,22 +293,49 @@ impl<'a> MovePicker<'a> {
         //
         // Transposition table move
         //
+        // Play the TT move before even generating legal moves.
+        // If we're lucky, the first move is a cutoff, and we saved ourselves
+        // the trouble of generating the legal moves.
+        //
         ////////////////////////////////////////////////////////////////////////
 
-        // Play TT move first (principal variation move)
         if self.stage == Stage::TTMove {
-            self.stage = Stage::ScoreTacticals;
+            self.stage = Stage::GenerateMoves;
 
-            let tt_move = self.tt_move.and_then(|tt| {
-                self.find_swap(self.index, self.moves.len(), |mv| mv == tt)
-            });
-
-            if tt_move.is_some() {
-                self.index += 1;
-                self.quiet_index += 1;
-                return tt_move;
+            if self.tt_move.is_some() {
+                return self.tt_move;
             }
         } 
+
+        ////////////////////////////////////////////////////////////////////////
+        //
+        // Generate legal moves
+        //
+        ////////////////////////////////////////////////////////////////////////
+
+        if self.stage == Stage::GenerateMoves {
+            self.moves = self.position.board.legal_moves::<ALL>();
+
+            self.bad_tactical_index = self.moves.len();
+
+            // If we played a TT move, move it to the front straight away
+            // and update the indices, so we don't treat it during the scoring
+            // phase.
+            if let Some(tt_move) = self.tt_move {
+                let found = self.find_swap(
+                    self.index, 
+                    self.moves.len(), 
+                    |mv| mv == tt_move
+                );
+
+                if found.is_some() {
+                    self.index += 1;
+                    self.quiet_index += 1;
+                }
+            }
+
+            self.stage = Stage::ScoreTacticals;
+        }
 
         ////////////////////////////////////////////////////////////////////////
         //
@@ -432,12 +443,10 @@ mod tests {
         // kiwipete
         let board: Board = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1".parse().unwrap();
         let position = Position::new(board);
-        let legal_moves = board.legal_moves::<true>();
         let history = HistoryTable::new();
 
-        let mut picker = MovePicker::new(
+        let mut picker = MovePicker::<true>::new(
             &position, 
-            legal_moves.clone(), 
             None, 
             Killers::new(), 
             None,

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -17,7 +17,6 @@ use super::Search;
 use super::params::IIR_THRESHOLD;
 use super::params::MAX_DEPTH;
 
-// Constants used for more readable const generics
 const QUIETS: bool = true;
 
 impl Position {
@@ -234,16 +233,6 @@ impl Position {
             countermove
         );
 
-        // Checkmate?
-        if legal_moves.len() == 0 && in_check {
-            return -Score::MATE + ply as Score;
-        }
-
-        // Stalemate?
-        if legal_moves.len() == 0 && !in_check {
-            return self.score.draw_score(ply, search.tc.nodes());
-        }
-
         ////////////////////////////////////////////////////////////////////////
         //
         // Iterate over the remaining moves
@@ -424,6 +413,8 @@ impl Position {
                 }
             }
 
+            move_count += 1;
+
             if score > best_score {
                 best_score = score;
             }
@@ -449,9 +440,18 @@ impl Position {
             if search.aborted {
                 return Score::MINUS_INF;
             }
-
-            move_count += 1;
         }
+
+        // Checkmate?
+        if move_count == 0 && in_check {
+            return -Score::MATE + ply as Score;
+        }
+
+        // Stalemate?
+        if move_count == 0 && !in_check {
+            return self.score.draw_score(ply, search.tc.nodes());
+        }
+
 
         ////////////////////////////////////////////////////////////////////////
         //

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -17,7 +17,7 @@ use super::Search;
 use super::params::IIR_THRESHOLD;
 use super::params::MAX_DEPTH;
 
-const QUIETS: bool = true;
+const ALL_MOVES: bool = true;
 
 impl Position {
     /// The main negamax function of the search routine.
@@ -225,9 +225,8 @@ impl Position {
 
         let countermove = prev_hist_idx.and_then(|idx| search.countermoves[idx]);
 
-        let mut legal_moves = MovePicker::new(
+        let mut legal_moves = MovePicker::<ALL_MOVES>::new(
             &self,  
-            self.board.legal_moves::<QUIETS>(),
             tt_move,
             search.killers[ply],
             countermove

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -15,7 +15,7 @@ use super::Search;
 
 // Constants used for more readable const generics
 const ALL: bool = true;
-const CAPTURES: bool = false;
+const TACTICALS: bool = false;
 
 impl Position {
     /// Perform a less intensive negamax search that only searches captures.
@@ -104,9 +104,8 @@ impl Position {
 
         let tt_move = tt_entry.and_then(|entry| entry.get_move());
 
-        let mut tacticals = MovePicker::new(
+        let mut tacticals = MovePicker::<TACTICALS>::new(
             &self,
-            self.board.legal_moves::<CAPTURES>(),
             tt_move,
             Killers::new(),
             None,

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -17,7 +17,6 @@ use super::Search;
 const ALL: bool = true;
 const CAPTURES: bool = false;
 
-
 impl Position {
     /// Perform a less intensive negamax search that only searches captures.
     ///
@@ -118,14 +117,7 @@ impl Position {
         let mut best_move = tt_move;
         let mut best_score = eval;
         let mut node_type = NodeType::Upper;
-
-        // If we're in check and there are no captures, we need to check
-        // whether it might be mate!
-        if in_check 
-            && tacticals.len() == 0 
-            && self.board.legal_moves::<ALL>().len() == 0 {
-            return -Score::MATE + ply as Score;
-        }
+        let mut move_count = 0;
 
        while let Some(mv) = tacticals.next(&search.history_table, None) {
             ////////////////////////////////////////////////////////////////////
@@ -173,6 +165,8 @@ impl Position {
                     search
                 );
 
+            move_count += 1;
+
             if score > best_score {
                 best_score = score;
             }
@@ -192,6 +186,16 @@ impl Position {
             if search.aborted {
                 return Score::MINUS_INF;
             }
+
+
+        }
+
+        // If we're in check and there are no captures, we need to check
+        // whether it might be mate!
+        if in_check 
+            && move_count == 0
+            && self.board.legal_moves::<ALL>().len() == 0 {
+            return -Score::MATE + ply as Score;
         }
 
         ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Yield TT move before even generating moves. If the TT move causes a cutoff, we save the work of generating the moves.

```
Score of Simbelmyne vs simbelmyne-main: 389 - 311 - 488  [0.533] 1188
...      Simbelmyne playing White: 212 - 144 - 239  [0.557] 595
...      Simbelmyne playing Black: 177 - 167 - 249  [0.508] 593
...      White vs Black: 379 - 321 - 488  [0.524] 1188
Elo difference: 22.8 +/- 15.2, LOS: 99.8 %, DrawRatio: 41.1 %
SPRT: llr 2.99 (101.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```