### PR TITLE
Only store a single board of checkers

### DIFF
--- a/chess/src/board.rs
+++ b/chess/src/board.rs
@@ -45,8 +45,8 @@ pub struct Board {
     // Mask of all pinrays, indexed by the color whose pieces are pinned
     pub pinrays: [Bitboard; Color::COUNT],
 
-    // Mask of all checkers, indexed by the color whose king is under attack
-    pub checkers: [Bitboard; Color::COUNT],
+    // Mask of all checkers
+    pub checkers: Bitboard
 }
 
 impl Board {
@@ -70,7 +70,7 @@ impl Board {
             half_moves,
             full_moves,
             pinrays: [Bitboard::EMPTY; 2],
-            checkers: [Bitboard::EMPTY; 2],
+            checkers: Bitboard::EMPTY,
         };
 
         board.pinrays = [
@@ -78,10 +78,7 @@ impl Board {
             board.compute_pinrays(Color::Black),
         ];
 
-        board.checkers = [
-            board.compute_checkers(Color::White),
-            board.compute_checkers(Color::Black),
-        ];
+        board.checkers = board.compute_checkers(current);
 
         board
 
@@ -174,8 +171,8 @@ impl Board {
         self.pinrays[us as usize]
     }
 
-    pub fn get_checkers(&self, us: Color) -> Bitboard {
-        self.checkers[us as usize]
+    pub fn get_checkers(&self) -> Bitboard {
+        self.checkers
     }
 
     pub fn get_promo_rank(&self) -> Bitboard {
@@ -327,7 +324,7 @@ impl Board {
 impl Board {
     /// Check whether the current player is in check
     pub fn in_check(&self) -> bool {
-        !self.get_checkers(self.current).is_empty()
+        !self.get_checkers().is_empty()
     }
 
     /// Check for rule_based draws

--- a/chess/src/movegen/legal_moves.rs
+++ b/chess/src/movegen/legal_moves.rs
@@ -36,7 +36,7 @@ impl Board {
         let ours = self.occupied_by(us);
         let theirs = self.occupied_by(them);
         let blockers = ours | theirs;
-        let checkers = self.get_checkers(us);
+        let checkers = self.get_checkers();
         let pinrays = self.pinrays[us as usize];
         let king_sq = self.kings(us).first();
         let in_check = checkers.count() > 0;
@@ -174,7 +174,7 @@ impl Board {
         let ours = self.occupied_by(us);
         let theirs = self.occupied_by(them);
         let blockers = ours | theirs;
-        let checkers = self.get_checkers(us);
+        let checkers = self.get_checkers();
         let pinrays = self.pinrays[us as usize];
         let king_sq = self.kings(us).first();
         let in_check = checkers.count() > 0;

--- a/chess/src/movegen/play_move.rs
+++ b/chess/src/movegen/play_move.rs
@@ -151,10 +151,7 @@ impl Board {
             new_board.compute_pinrays(Black)
         ];
 
-        new_board.checkers = [
-            new_board.compute_checkers(White), 
-            new_board.compute_checkers(Black)
-        ];
+        new_board.checkers = new_board.compute_checkers(new_board.current);
 
         new_board
     }


### PR DESCRIPTION
The second board is, by definition, empty, and wasn't being used anywhere.

_Slight_ speedup of around 1%, on average, but the SPRT seemed to be failing? Wasn't using non-regression bounds, though, so maybe that's why?