### PR TITLE
Sort killers in FIFO order

### DIFF
--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -255,9 +255,13 @@ impl<'pos, const ALL: bool> MovePicker<'pos, ALL> {
         for i in self.quiet_index..self.moves.len() {
             let mv = &self.moves[i];
 
-            if self.killers.moves().contains(mv) {
+            if self.killers.len() > 0 && mv == &self.killers.moves()[0] {
+                self.scores[i] += 2 * KILLER_BONUS;
+            }
+
+            if self.killers.len() > 1 && mv == &self.killers.moves()[1] {
                 self.scores[i] += KILLER_BONUS;
-            } 
+            }
 
             if let Some(countermove) = self.countermove {
                 if countermove == *mv {


### PR DESCRIPTION
Makes 0 difference, but will hopefully make it a little easier to verify we didn't fuck up staged movegen later. (Bench shouldn't change when we stage killers, countermoves and quiets)