### PR TITLE
Clear the next ply's killers

### DIFF
--- a/simbelmyne/src/history_tables/killers.rs
+++ b/simbelmyne/src/history_tables/killers.rs
@@ -39,7 +39,10 @@ impl Killers {
     // Return the moves in the table
     pub fn moves(&self) -> &[Move] {
         &self.moves[..self.len]
+    }
 
+    pub fn clear(&mut self) {
+        self.len = 0;
     }
 
     /// Add a killer move to the front of the table, with the additional 

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -125,6 +125,20 @@ impl Position {
 
         ////////////////////////////////////////////////////////////////////////
         //
+        // Clear the next ply's killers table
+        //
+        // In order to make the killer moves stored in the killers table more
+        // relevant, we clear the killers table for the upcoming ply, so we're
+        // guaranteed that all of our child nodes will only see killers that
+        // come directly from their siblings.
+        //
+        ////////////////////////////////////////////////////////////////////////
+
+        search.killers[ply + 1].clear();
+
+
+        ////////////////////////////////////////////////////////////////////////
+        //
         // Improving heuristic:
         //
         // If our eval is better than two plies ago, we can


### PR DESCRIPTION
The idea is to make the killers table more relevant to the current subtree. Clear the next ply's killers table in each node, to guarantee that each node's children only see killers from their siblings.

Bench: 4935909

```
Elo   | 10.90 +- 6.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5484 W: 1745 L: 1573 D: 2166
Penta | [151, 615, 1085, 693, 198]
https://chess.samroelants.com/test/14/
```