### PR TITLE
Use single conthist table for 1ply and 2ply

### DIFF
--- a/simbelmyne/src/cli/bench.rs
+++ b/simbelmyne/src/cli/bench.rs
@@ -93,13 +93,13 @@ pub fn run_single(fen: &str, depth: usize) -> BenchResult {
     let mut tt = TTable::with_capacity(16);
     let (mut tc, _handle) = TimeController::new(TimeControl::Depth(depth), board);
     let mut history = HistoryTable::new();
-    let mut conthists = [ContHist::boxed(), ContHist::boxed()];
+    let mut conthist = ContHist::boxed();
 
     let search_params = SearchParams::default();
     let search = position.search::<NO_DEBUG>(
         &mut tt, 
         &mut history, 
-        &mut conthists,
+        &mut conthist,
         &mut tc, 
         &search_params
     );

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -83,7 +83,7 @@ pub struct Search<'a> {
     pub history_table: &'a mut HistoryTable,
 
     /// Continuation history table
-    pub conthist_tables: &'a mut [Box<ContHist>; 2],
+    pub conthist_table: &'a mut ContHist,
 }
 
 impl<'a> Search<'a> {
@@ -91,7 +91,7 @@ impl<'a> Search<'a> {
     pub fn new(
         depth: usize, 
         history_table: &'a mut HistoryTable, 
-        conthist_tables: &'a mut [Box<ContHist>; 2],
+        conthist_table: &'a mut ContHist,
         tc: &'a mut TimeController, 
         search_params: &'a SearchParams
     ) -> Self {
@@ -102,7 +102,7 @@ impl<'a> Search<'a> {
             killers: [Killers::new(); MAX_DEPTH],
             countermoves: CountermoveTable::boxed(),
             history_table,
-            conthist_tables,
+            conthist_table,
             search_params,
             aborted: false,
             stack: [SearchStackEntry::default(); MAX_DEPTH],
@@ -124,7 +124,7 @@ impl Position {
         &self, 
         tt: &mut TTable, 
         history: &mut HistoryTable, 
-        conthists: &mut [Box<ContHist>; 2], 
+        conthist: &mut ContHist,
         tc: &mut TimeController, 
         search_params: &SearchParams
     ) -> SearchReport {
@@ -141,7 +141,7 @@ impl Position {
             let mut search = Search::new(
                 depth, 
                 history, 
-                conthists, 
+                conthist, 
                 tc, 
                 search_params
             );

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -251,10 +251,10 @@ impl Position {
         let mut local_pv = PVTable::new();
 
         let oneply_conthist = oneply_hist_idx
-            .map(|prev_idx| search.conthist_tables[0][prev_idx]);
+            .map(|prev_idx| search.conthist_table[prev_idx]);
 
         let twoply_conthist = twoply_hist_idx
-            .map(|pprev_idx| search.conthist_tables[1][pprev_idx]);
+            .map(|pprev_idx| search.conthist_table[pprev_idx]);
 
         while let Some(mv) = legal_moves.next(
             &search.history_table, 
@@ -508,15 +508,15 @@ impl Position {
                 let twoply = twoply_hist_idx.unwrap();
 
                 search.history_table[idx] += bonus;
-                search.conthist_tables[0][oneply][idx] += bonus;
-                search.conthist_tables[1][twoply][idx] += bonus;
+                search.conthist_table[oneply][idx] += bonus;
+                search.conthist_table[twoply][idx] += bonus;
 
                 // Deduct penalty for all tried quiets that didn't fail high
                 for mv in quiets_tried {
                     let idx = HistoryIndex::new(&self.board, mv);
                     search.history_table[idx] -= bonus;
-                    search.conthist_tables[0][oneply][idx] -= bonus;
-                    search.conthist_tables[1][twoply][idx] -= bonus;
+                    search.conthist_table[oneply][idx] -= bonus;
+                    search.conthist_table[twoply][idx] -= bonus;
                 }
 
                 search.countermoves[oneply] = Some(best_move);
@@ -527,13 +527,13 @@ impl Position {
             else if ply >= 1 {
                 let oneply = oneply_hist_idx.unwrap();
                 search.history_table[idx] += bonus;
-                search.conthist_tables[0][oneply][idx] += bonus;
+                search.conthist_table[oneply][idx] += bonus;
 
                 // Deduct penalty for all tried quiets that didn't fail high
                 for mv in quiets_tried {
                     let idx = HistoryIndex::new(&self.board, mv);
                     search.history_table[idx] -= bonus;
-                    search.conthist_tables[0][oneply][idx] -= bonus;
+                    search.conthist_table[oneply][idx] -= bonus;
                 }
 
                 search.countermoves[oneply] = Some(best_move);

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -492,7 +492,7 @@ impl SearchThread {
             let mut tt_size = DEFAULT_TT_SIZE;
             let mut tt = TTable::with_capacity(tt_size);
             let mut history = HistoryTable::new();
-            let mut conthists = [ContHist::boxed(), ContHist::boxed()];
+            let mut conthist = ContHist::boxed();
             let mut search_params = SearchParams::default();
 
             for msg in rx.iter() {
@@ -503,7 +503,7 @@ impl SearchThread {
                         let report = position.search::<DEBUG>(
                             &mut tt, 
                             &mut history, 
-                            &mut conthists,
+                            &mut conthist,
                             &mut tc, 
                             &search_params
                         );


### PR DESCRIPTION
Because we're indexing by color, these entries can never overlap:

```
  +------------+----------------+---------------+
  |            |  White piece   |   Black piece |
  +------------+----------------+---------------+
  |White piece | 2 ply (white)  | 1 ply (white) |
  +------------+----------------+---------------+
  |Black piece | 1 ply (black)  | 2 ply (black) |
  +------------+----------------+---------------+
```

Bench: 5002464