### PR TITLE
Replace "king threats" with actual threats

### DIFF
--- a/chess/src/board.rs
+++ b/chess/src/board.rs
@@ -96,7 +96,7 @@ impl Board {
 
         board.checkers = board.compute_checkers();
 
-        board.threats = board.king_threats();
+        board.threats = board.attacked_squares();
 
         board
     }
@@ -239,6 +239,33 @@ impl Board {
 ////////////////////////////////////////////////////////////////////////////////
 
 impl Board {
+    /// Calculate a map of squares attacked by the oponent
+    pub fn attacked_squares(&self) -> Bitboard {
+        let mut attacked = Bitboard(0);
+        let us = self.current;
+        let blockers = self.all_occupied();
+
+        attacked |= self.pawn_attacks(!us);
+
+        for square in self.knights(!us) {
+            attacked |= square.knight_squares();
+        }
+
+        for square in self.diag_sliders(!us) {
+            attacked |= square.bishop_squares(blockers);
+        }
+
+        for square in self.hv_sliders(!us) {
+            attacked |= square.rook_squares(blockers);
+        }
+
+        for square in self.kings(!us) {
+            attacked |= square.king_squares();
+        }
+
+        attacked
+    }
+
     /// Calculate a map of king threats
     ///
     /// King threats are all the squares that are unsafe for the king to move to.

--- a/chess/src/movegen/legal_moves.rs
+++ b/chess/src/movegen/legal_moves.rs
@@ -476,7 +476,7 @@ impl Board {
         let ours = self.occupied_by(us);
         let theirs = self.occupied_by(!us);
         let king_sq = self.kings(us).first();
-        let targets = king_sq.king_squares() & !ours & !self.get_threats();
+        let targets = king_sq.king_squares() & !ours & !self.king_threats();
 
         if GT::TACTICALS {
             for target in targets & theirs {
@@ -743,7 +743,7 @@ impl Board {
         }
 
         // King can't move into check
-        if piece.is_king() && self.threats.contains(tgt) {
+        if piece.is_king() && self.king_threats().contains(tgt) {
             return false;
         }
 


### PR DESCRIPTION
Remove king threats in favor of regular threats.

Doesn't seem to impact strength at all, but makes it a little easier to compare with others.

```
Elo   | -0.55 +- 3.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.44 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 20164 W: 6039 L: 6071 D: 8054
Penta | [674, 2371, 4026, 2335, 676]
https://chess.samroelants.com/test/80/
```

bench 4884710