### PR TITLE
Make `is_quiet()` return true for non-tacticals

### DIFF
--- a/chess/src/movegen/moves.rs
+++ b/chess/src/movegen/moves.rs
@@ -52,9 +52,13 @@ impl Move {
         unsafe { MoveType::new_unchecked(idx as u8) }
     }
 
-    /// Check whether the move is quiet (no capture, promotion, castle, etc...)
+    /// Check whether the move is quiet (not a tactical)
+    ///
+    /// NOTE: Unlike the other helpers, this method _does not_ return whether
+    /// the move_type is `Quiet`. Instead, it returns whether or not the 
+    /// move is !tactical.
     pub fn is_quiet(self) -> bool {
-        self.get_type() == MoveType::Quiet
+        !self.is_tactical()
     }
 
     /// Check whether the move is a castling move

--- a/simbelmyne/src/history_tables/mod.rs
+++ b/simbelmyne/src/history_tables/mod.rs
@@ -85,7 +85,7 @@ impl History {
             self.tact_hist[victim][idx] += bonus;
         } 
 
-        else if mv.is_quiet() {
+        else {
             let threat_idx = ThreatIndex::new(board.threats, mv);
             self.main_hist[threat_idx][idx] += bonus;
 

--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -387,7 +387,7 @@ impl<'a, const ALL: bool> MovePicker<'a, ALL> {
             // If we played a TT move, move it to the front straight away
             // and update the indices, so we don't treat it during the scoring
             // phase.
-            if let Some(tt_move) = self.tt_move.filter(|mv| !mv.is_tactical()) {
+            if let Some(tt_move) = self.tt_move.filter(|mv| mv.is_quiet()) {
                 let found = self.find_swap(
                     self.index, 
                     self.moves.len(), 

--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -387,7 +387,7 @@ impl<'a, const ALL: bool> MovePicker<'a, ALL> {
             // If we played a TT move, move it to the front straight away
             // and update the indices, so we don't treat it during the scoring
             // phase.
-            if let Some(tt_move) = self.tt_move.filter(|mv| mv.is_quiet()) {
+            if let Some(tt_move) = self.tt_move.filter(|mv| !mv.is_tactical()) {
                 let found = self.find_swap(
                     self.index, 
                     self.moves.len(), 

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -313,7 +313,7 @@ impl Position {
             }
 
             local_pv.clear();
-            let is_quiet = mv.is_quiet();
+            let is_quiet = !mv.is_tactical();
 
             if !search.tc.should_continue() {
                 search.aborted = true;

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -313,7 +313,6 @@ impl Position {
             }
 
             local_pv.clear();
-            let is_quiet = !mv.is_tactical();
 
             if !search.tc.should_continue() {
                 search.aborted = true;
@@ -357,7 +356,7 @@ impl Position {
             let see_margin = -see_quiet_margin() * depth as Score;
 
             if legal_moves.stage() > Stage::GoodTacticals
-                && is_quiet
+                && mv.is_quiet()
                 && move_count > 0
                 && !in_root
                 && !best_score.is_mate()
@@ -559,7 +558,7 @@ impl Position {
                     reduction -= next_position.board.in_check() as i16;
 
                     // Reduce moves with good history less, with bad history more
-                    if mv.is_quiet() {
+                    if !mv.is_tactical() {
                         reduction -= (legal_moves.current_score() / hist_lmr_divisor()) as i16;
                     }
 
@@ -629,7 +628,7 @@ impl Position {
             }
 
             // Fail-low moves get marked for history score penalty
-            if score < alpha && mv.is_quiet() {
+            if score < alpha && !mv.is_tactical() {
                 quiets_tried.push(mv);
             }
 
@@ -681,7 +680,7 @@ impl Position {
             //
             ////////////////////////////////////////////////////////////////////
 
-            if best_move.is_quiet() {
+            if !best_move.is_tactical() {
                 // New history table
                 search.history.add_hist_bonus(best_move, &self.board, bonus);
                 search.history.add_killer(ply, best_move);

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -10,6 +10,7 @@ use crate::position::Position;
 use crate::evaluate::Score;
 use chess::movegen::legal_moves::MoveList;
 use chess::movegen::moves::Move;
+use chess::movegen::moves::MoveType;
 
 use super::params::*;
 use super::params::lmr_reduction;
@@ -356,7 +357,9 @@ impl Position {
             let see_margin = -see_quiet_margin() * depth as Score;
 
             if legal_moves.stage() > Stage::GoodTacticals
-                && mv.is_quiet()
+                // FIXME: Make this mv.is_quiet() at some point, but tweak the
+                // pruning margin
+                && mv.get_type() == MoveType::Quiet
                 && move_count > 0
                 && !in_root
                 && !best_score.is_mate()
@@ -447,7 +450,7 @@ impl Position {
                         // If the tt move is quiet (and otherwise unexpected to 
                         // be amazing), but beats se_beta by a _large_ margin,
                         // extend once more!
-                        if !mv.is_tactical() && value < se_beta - triple_ext_margin() {
+                        if mv.is_quiet() && value < se_beta - triple_ext_margin() {
                           extension += 1;
                         }
                     } 
@@ -558,7 +561,7 @@ impl Position {
                     reduction -= next_position.board.in_check() as i16;
 
                     // Reduce moves with good history less, with bad history more
-                    if !mv.is_tactical() {
+                    if mv.is_quiet() {
                         reduction -= (legal_moves.current_score() / hist_lmr_divisor()) as i16;
                     }
 
@@ -628,7 +631,7 @@ impl Position {
             }
 
             // Fail-low moves get marked for history score penalty
-            if score < alpha && !mv.is_tactical() {
+            if score < alpha && mv.is_quiet() {
                 quiets_tried.push(mv);
             }
 
@@ -680,7 +683,7 @@ impl Position {
             //
             ////////////////////////////////////////////////////////////////////
 
-            if !best_move.is_tactical() {
+            if best_move.is_quiet() {
                 // New history table
                 search.history.add_hist_bonus(best_move, &self.board, bonus);
                 search.history.add_killer(ply, best_move);
@@ -699,7 +702,7 @@ impl Position {
             ////////////////////////////////////////////////////////////////////
 
             // Add a bonus for the move that caused the cutoff
-            else if best_move.is_tactical() {
+            else {
                 search.history.add_hist_bonus(best_move, &self.board, bonus);
             } 
 


### PR DESCRIPTION
Turns out SEE pruning was the one causing it to lose.

If I fix it everywhere _except_ in SEE pruning, we gain quite a bit!

```
Elo   | 24.67 +- 10.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 1820 W: 568 L: 439 D: 813
Penta | [28, 190, 378, 253, 61]
https://chess.samroelants.com/test/240/
```

It's a regression test, but I feel pretty confident it's a gainer...