### PR TITLE
Double extensions

### DIFF
--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -293,5 +293,7 @@ struct SearchStackEntry {
 
     /// A move to be excluded from the search at this ply (used for singular
     /// extensions
-    pub excluded: Option<Move>
+    pub excluded: Option<Move>,
+
+    pub double_exts: u8
 }

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -206,4 +206,4 @@ pub const SE_MARGIN: Score = 2;
 pub const SE_TT_DELTA: usize = 3;
 
 pub const DOUBLE_EXT_MARGIN: Score = 20;
-pub const DOUBLE_EXT_MAX: u8 = 10;
+pub const DOUBLE_EXT_MAX: u8 = 5; 

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -206,4 +206,4 @@ pub const SE_MARGIN: Score = 2;
 pub const SE_TT_DELTA: usize = 3;
 
 pub const DOUBLE_EXT_MARGIN: Score = 17;
-pub const DOUBLE_EXT_MAX: u8 = 10; 
+pub const DOUBLE_EXT_MAX: u8 = 4; 

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -205,5 +205,5 @@ pub const SE_THRESHOLD: usize = 8;
 pub const SE_MARGIN: Score = 2;
 pub const SE_TT_DELTA: usize = 3;
 
-pub const DOUBLE_EXT_MARGIN: Score = 20;
-pub const DOUBLE_EXT_MAX: u8 = 5; 
+pub const DOUBLE_EXT_MARGIN: Score = 17;
+pub const DOUBLE_EXT_MAX: u8 = 10; 

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -51,7 +51,10 @@ pub struct SearchParams {
     // Singular extensions
     pub se_threshold: usize,
     pub se_margin: Score,
-    pub se_tt_delta: usize
+    pub se_tt_delta: usize,
+
+    pub double_ext_margin: Score,
+    pub double_ext_max: u8,
 }
 
 impl Default for SearchParams {
@@ -95,6 +98,9 @@ impl Default for SearchParams {
             se_threshold: SE_THRESHOLD,
             se_margin: SE_MARGIN,
             se_tt_delta: SE_TT_DELTA,
+
+            double_ext_margin: DOUBLE_EXT_MARGIN,
+            double_ext_max: DOUBLE_EXT_MAX
         }
     }
 }
@@ -198,3 +204,6 @@ pub const SEE_QUIET_MARGIN: Score = -40;
 pub const SE_THRESHOLD: usize = 8;
 pub const SE_MARGIN: Score = 2;
 pub const SE_TT_DELTA: usize = 3;
+
+pub const DOUBLE_EXT_MARGIN: Score = 20;
+pub const DOUBLE_EXT_MAX: u8 = 10;

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -27,6 +27,7 @@ use crate::search::params::ASPIRATION_MAX_WINDOW;
 use crate::search::params::ASPIRATION_MIN_DEPTH;
 use crate::search::params::DEFAULT_TT_SIZE;
 use crate::search::params::DELTA_PRUNING_MARGIN;
+use crate::search::params::DOUBLE_EXT_MARGIN;
 use crate::search::params::FP_BASE;
 use crate::search::params::FP_MARGIN;
 use crate::search::params::FP_THRESHOLD;
@@ -78,7 +79,7 @@ pub struct SearchController {
     search_params: SearchParams,
 }
 
-const UCI_OPTIONS: [UciOption; 23] = [
+const UCI_OPTIONS: [UciOption; 25] = [
     UciOption { 
         name: "Hash",
         option_type: OptionType::Spin { 
@@ -87,6 +88,7 @@ const UCI_OPTIONS: [UciOption; 23] = [
             default: DEFAULT_TT_SIZE as i32
         }
     },
+
     UciOption { 
         name: "Threads",
         option_type: OptionType::Spin { 
@@ -281,6 +283,24 @@ const UCI_OPTIONS: [UciOption; 23] = [
             min: 1,
             max: 6,
             default: SE_TT_DELTA as i32,
+        }
+    },
+
+    UciOption { 
+        name: "double_ext_margin",
+        option_type: OptionType::Spin {
+            min: 0,
+            max: 30,
+            default: DOUBLE_EXT_MARGIN as i32,
+        }
+    },
+
+    UciOption { 
+        name: "double_ext_max",
+        option_type: OptionType::Spin {
+            min: 0,
+            max: 20,
+            default: DOUBLE_EXT_MAX as u8,
         }
     },
 ];
@@ -495,6 +515,18 @@ impl SearchController {
                                 "se_tt_delta" => {
                                     let value: usize = value.parse()?;
                                     self.search_params.se_tt_delta = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "double_ext_margin" => {
+                                    let value: Score = value.parse()?;
+                                    self.search_params.double_ext_margin = value;
+                                    self.search_thread.set_search_params(self.search_params.clone())
+                                },
+
+                                "double_ext_max" => {
+                                    let value: u8 = value.parse()?;
+                                    self.search_params.double_ext_max = value;
                                     self.search_thread.set_search_params(self.search_params.clone())
                                 },
 

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -28,6 +28,7 @@ use crate::search::params::ASPIRATION_MIN_DEPTH;
 use crate::search::params::DEFAULT_TT_SIZE;
 use crate::search::params::DELTA_PRUNING_MARGIN;
 use crate::search::params::DOUBLE_EXT_MARGIN;
+use crate::search::params::DOUBLE_EXT_MAX;
 use crate::search::params::FP_BASE;
 use crate::search::params::FP_MARGIN;
 use crate::search::params::FP_THRESHOLD;
@@ -300,7 +301,7 @@ const UCI_OPTIONS: [UciOption; 25] = [
         option_type: OptionType::Spin {
             min: 0,
             max: 20,
-            default: DOUBLE_EXT_MAX as u8,
+            default: DOUBLE_EXT_MAX as i32,
         }
     },
 ];


### PR DESCRIPTION
```
Elo   | 11.86 +- 6.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4982 W: 1529 L: 1359 D: 2094
Penta | [139, 530, 1009, 648, 165]
https://chess.samroelants.com/test/126/
```

bench 8394692