### PR TITLE
Refactor/global params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,30 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "ansi_colours"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1558bd2075d341b9ca698ec8eb6fcc55a746b1fc4255585aad5b141d918a80"
+dependencies = [
+ "rgb",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +88,142 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bat"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc9e5637c2330d8eb7b920f2aa5d9e184446c258466f825ea1412c7614cc86"
+dependencies = [
+ "ansi_colours",
+ "bincode",
+ "bytesize",
+ "clircle",
+ "console",
+ "content_inspector",
+ "encoding_rs",
+ "flate2",
+ "globset",
+ "grep-cli",
+ "home",
+ "nu-ansi-term",
+ "once_cell",
+ "path_abs",
+ "plist",
+ "semver",
+ "serde",
+ "serde_yaml",
+ "shell-words",
+ "syntect",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bytemuck"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+
+[[package]]
+name = "bytesize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+
+[[package]]
+name = "cargo-expand"
+version = "1.0.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2c4a023bc362bd45ca09513e28b38c852fe15a270e0c49792b487a5059a09d"
+dependencies = [
+ "bat",
+ "cargo-subcommand-metadata",
+ "clap",
+ "fs-err",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "shlex",
+ "syn",
+ "syn-select",
+ "tempfile",
+ "termcolor",
+ "toml",
+ "toolchain_find",
+]
+
+[[package]]
+name = "cargo-subcommand-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33d3b80a8db16c4ad7676653766a8e59b5f95443c8823cb7cff587b90cb91ba"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +264,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
+name = "clircle"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e87cbed5354f17bd8ca8821a097fb62599787fe8f611743fad7ee156a0a600"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "serde",
+ "winapi",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +289,37 @@ checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
  "lazy_static",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -145,16 +348,149 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "flate2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "grep-cli"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea40788c059ab8b622c4d074732750bfb3bd2912e2dd58eabc11798a4d5ad725"
+dependencies = [
+ "bstr",
+ "globset",
+ "libc",
+ "log",
+ "termcolor",
+ "winapi-util",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -172,10 +508,117 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.155"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "macros"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "simbelmyne-uci",
+ "syn",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "path_abs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ef02f6342ac01d8a93b65f96db53fe68a92a15f41144f97fb00a9e669633c3"
+dependencies = [
+ "std_prelude",
+]
+
+[[package]]
+name = "plist"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -184,6 +627,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -216,17 +668,157 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "rgb"
+version = "0.8.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aee83dc281d5a3200d37b299acd13b81066ea126a7f16f0eae70fc9aed241d9"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
+name = "serde"
+version = "1.0.204"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.204"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "simbelmyne"
 version = "1.9.0"
 dependencies = [
  "anyhow",
  "arrayvec",
+ "cargo-expand",
  "clap",
  "colored",
  "itertools",
+ "macros",
  "rayon",
  "simbelmyne-chess",
  "simbelmyne-uci",
+ "syn",
  "tuner",
 ]
 
@@ -250,6 +842,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "std_prelude"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,13 +855,161 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.68"
+version = "2.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-select"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea24402791e2625a28bcaf662046e09a48a7610f806688cf35901d78ba938bb4"
+dependencies = [
+ "syn",
+]
+
+[[package]]
+name = "syntect"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
+dependencies = [
+ "bincode",
+ "bitflags 1.3.2",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toolchain_find"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc8c9a7f0a2966e1acdaf0461023d0b01471eeead645370cf4c3f5cff153f2a"
+dependencies = [
+ "home",
+ "once_cell",
+ "regex",
+ "semver",
+ "walkdir",
 ]
 
 [[package]]
@@ -281,10 +1027,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -424,3 +1223,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,30 +3,6 @@
 version = 3
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "ansi_colours"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a1558bd2075d341b9ca698ec8eb6fcc55a746b1fc4255585aad5b141d918a80"
-dependencies = [
- "rgb",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,142 +64,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "autocfg"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bat"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc9e5637c2330d8eb7b920f2aa5d9e184446c258466f825ea1412c7614cc86"
-dependencies = [
- "ansi_colours",
- "bincode",
- "bytesize",
- "clircle",
- "console",
- "content_inspector",
- "encoding_rs",
- "flate2",
- "globset",
- "grep-cli",
- "home",
- "nu-ansi-term",
- "once_cell",
- "path_abs",
- "plist",
- "semver",
- "serde",
- "serde_yaml",
- "shell-words",
- "syntect",
- "thiserror",
- "unicode-width",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "bstr"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
-name = "bytemuck"
-version = "1.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
-
-[[package]]
-name = "bytesize"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
-
-[[package]]
-name = "cargo-expand"
-version = "1.0.88"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2c4a023bc362bd45ca09513e28b38c852fe15a270e0c49792b487a5059a09d"
-dependencies = [
- "bat",
- "cargo-subcommand-metadata",
- "clap",
- "fs-err",
- "prettyplease",
- "proc-macro2",
- "quote",
- "serde",
- "shlex",
- "syn",
- "syn-select",
- "tempfile",
- "termcolor",
- "toml",
- "toolchain_find",
-]
-
-[[package]]
-name = "cargo-subcommand-metadata"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33d3b80a8db16c4ad7676653766a8e59b5f95443c8823cb7cff587b90cb91ba"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "clap"
 version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,18 +104,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
-name = "clircle"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e87cbed5354f17bd8ca8821a097fb62599787fe8f611743fad7ee156a0a600"
-dependencies = [
- "cfg-if",
- "libc",
- "serde",
- "winapi",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,37 +117,6 @@ checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
  "lazy_static",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "console"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "unicode-width",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "content_inspector"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -348,149 +145,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "errno"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "fancy-regex"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
-dependencies = [
- "bit-set",
- "regex",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
-
-[[package]]
-name = "flate2"
-version = "1.0.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "fs-err"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "globset"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "grep-cli"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea40788c059ab8b622c4d074732750bfb3bd2912e2dd58eabc11798a4d5ad725"
-dependencies = [
- "bstr",
- "globset",
- "libc",
- "log",
- "termcolor",
- "winapi-util",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -508,34 +172,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "libc"
-version = "0.2.155"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
-name = "log"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "macros"
@@ -547,95 +187,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "once_cell"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "path_abs"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ef02f6342ac01d8a93b65f96db53fe68a92a15f41144f97fb00a9e669633c3"
-dependencies = [
- "std_prelude",
-]
-
-[[package]]
-name = "plist"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
-dependencies = [
- "base64",
- "indexmap",
- "quick-xml",
- "serde",
- "time",
-]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "prettyplease"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -668,149 +225,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
-
-[[package]]
-name = "rgb"
-version = "0.8.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aee83dc281d5a3200d37b299acd13b81066ea126a7f16f0eae70fc9aed241d9"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
-dependencies = [
- "bitflags 2.6.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "ryu"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
-
-[[package]]
-name = "serde"
-version = "1.0.204"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.204"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.120"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
-name = "shell-words"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "simbelmyne"
 version = "1.9.0"
 dependencies = [
  "anyhow",
  "arrayvec",
- "cargo-expand",
  "clap",
  "colored",
  "itertools",
@@ -818,7 +237,6 @@ dependencies = [
  "rayon",
  "simbelmyne-chess",
  "simbelmyne-uci",
- "syn",
  "tuner",
 ]
 
@@ -842,12 +260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "std_prelude"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,154 +277,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn-select"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea24402791e2625a28bcaf662046e09a48a7610f806688cf35901d78ba938bb4"
-dependencies = [
- "syn",
-]
-
-[[package]]
-name = "syntect"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
-dependencies = [
- "bincode",
- "bitflags 1.3.2",
- "fancy-regex",
- "flate2",
- "fnv",
- "once_cell",
- "regex-syntax",
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror",
- "walkdir",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
-dependencies = [
- "cfg-if",
- "fastrand",
- "rustix",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.3.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
-name = "toolchain_find"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc8c9a7f0a2966e1acdaf0461023d0b01471eeead645370cf4c3f5cff153f2a"
-dependencies = [
- "home",
- "once_cell",
- "regex",
- "semver",
- "walkdir",
-]
-
-[[package]]
 name = "tuner"
 version = "0.1.0"
 dependencies = [
@@ -1027,63 +291,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -1223,12 +434,3 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
-
-[[package]]
-name = "winnow"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
-dependencies = [
- "memchr",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [ "simbelmyne", "chess", "uci", "tuner" ]
+members = [ "simbelmyne", "chess", "uci", "tuner", "macros"]
 default-members = ["simbelmyne"]
 
 [profile.release]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0.36"
+syn = { version = "2.0.70", features = ["extra-traits", "full", "visit"] }
+uci = { path = "../uci", package = "simbelmyne-uci" }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,174 @@
+use proc_macro::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{punctuated::Punctuated, visit::Visit, Attribute, Expr, ExprLit, Item, ItemConst, Lit, Meta,Token };
+
+#[proc_macro_attribute]
+pub fn tunable(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let ast: syn::Item = syn::parse(item.clone()).unwrap();
+
+    let mut params = Params { params: vec![] };
+    params.visit_item(&ast);
+
+    let decls = &params.params.clone()
+        .into_iter()
+        .map(|item| replace_decl(item))
+        .collect::<Vec<_>>();
+
+    let uci_decls = &params.params
+        .iter()
+        .filter(|item| is_uci_option(item))
+        .collect::<Vec<_>>();
+
+    let uci_opts = uci_decls
+        .iter()
+        .map(|item| to_uci_option(item))
+        .collect::<Vec<_>>();
+
+    let num_uci_opts = uci_opts.len();
+
+    let Item::Mod(mod_item) = &ast else { 
+        panic!("#[tunable] proc macro should be used on a module") 
+    };
+
+    let mod_ident = &mod_item.ident;
+
+    let rewritten = quote! {
+        pub mod #mod_ident {
+            use std::sync::atomic::*;
+            use uci::options::OptionType;
+            use uci::options::UciOption;
+
+            #(#decls)*
+
+            pub const SPSA_UCI_OPTIONS: [UciOption; #num_uci_opts] = [
+                #(#uci_opts),*
+            ];
+        }
+    };
+
+    TokenStream::from(rewritten)
+}
+
+
+fn is_uci_option(item: &ItemConst) -> bool {
+    if item.attrs.len() == 0 {
+        return false;
+    }
+
+    item.attrs[0].path().is_ident("uci")
+}
+
+fn to_uci_option(item: &ItemConst) -> impl ToTokens {
+    let ident = &item.ident;
+    let default = &item.expr;
+
+    let uci_option_string = &ident.to_string().to_ascii_lowercase();
+    let (min, max, step) = parse_uci_attr(&item.attrs[0]);
+
+    quote! {
+        UciOption {
+            name: #uci_option_string,
+            option_type: OptionType::Spin { 
+                min: #min, 
+                max: #max, 
+                default: #default,
+                step: #step,
+            }
+        }
+    }
+}
+
+fn parse_uci_attr(attr: &Attribute) -> (i32, i32, i32) {
+    let mut min = 0;
+    let mut max = 0;
+    let mut step = 0;
+
+    let nested = attr
+        .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+        .expect("Failed to parse arguments to uci attribute");
+
+    for meta in nested {
+        let Meta::NameValue(meta) = meta else { panic!("Invalid param passed to uci attr") };
+
+        if meta.path.is_ident("min") {
+            let Expr::Lit(ExprLit { 
+                lit: Lit::Int(value)
+                , .. 
+            }) = &meta.value else { panic!("Value passed to min is not an int literal") };
+
+            min = value.base10_parse().expect("Failed to parse min value");
+        }
+
+        if meta.path.is_ident("max") {
+            let Expr::Lit(ExprLit { 
+                lit: Lit::Int(value)
+                , .. 
+            }) = &meta.value else { panic!("Value passed to min is not an int literal") };
+
+            max = value.base10_parse().expect("Failed to parse min value");
+        }
+
+        if meta.path.is_ident("step") {
+            let Expr::Lit(ExprLit { 
+                lit: Lit::Int(value)
+                , .. 
+            }) = &meta.value else { panic!("Value passed to min is not an int literal") };
+
+            step = value.base10_parse().expect("Failed to parse min value");
+        }
+    }
+
+    (min, max, step)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Params
+//
+// A Params struct holds all the const declarations of the params
+//
+////////////////////////////////////////////////////////////////////////////////
+
+/// A struct that holds all of the const assignments
+struct Params<'ast> {
+    params: Vec<&'ast ItemConst>
+}
+
+impl<'ast> Visit<'ast> for Params<'ast> {
+    fn visit_item_const(&mut self, item: &'ast ItemConst) {
+        self.params.push(item);
+    }
+}
+
+fn replace_decl(item: &ItemConst) -> impl ToTokens {
+    let ident = &item.ident;
+    let ty = &item.ty;
+    let expr = &item.expr;
+
+    // Generate atomic type identifier
+
+    let getter_ident = syn::Ident::new(
+        &ident.to_string().to_ascii_lowercase(), 
+        ident.span()
+    );
+
+    quote! {
+        #[cfg(not(feature = "spsa"))]
+        const #ident: #ty = #expr;
+
+        #[cfg(not(feature = "spsa"))]
+        pub fn #getter_ident() -> #ty {
+            #ident
+        }
+
+        #[cfg(feature = "spsa")]
+        const #ident: AtomicI32 = AtomicI32::new(#expr);
+
+        #[cfg(feature = "spsa")]
+        pub fn #getter_ident() -> #ty {
+            #ident.load(Ordering::Relaxed) as #ty
+        }
+    }
+}
+
+

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -174,7 +174,8 @@ fn replace_decl(item: &ItemConst) -> impl ToTokens {
         const #ident: #ty = #expr;
 
         #[cfg(not(feature = "spsa"))]
-        pub fn #getter_ident() -> #ty {
+        #[inline(always)]
+        pub const fn #getter_ident() -> #ty {
             #ident
         }
 
@@ -182,10 +183,9 @@ fn replace_decl(item: &ItemConst) -> impl ToTokens {
         const #ident: AtomicI32 = AtomicI32::new(#expr);
 
         #[cfg(feature = "spsa")]
+        #[inline(always)]
         pub fn #getter_ident() -> #ty {
             #ident.load(Ordering::Relaxed) as #ty
         }
     }
 }
-
-

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -24,6 +24,16 @@ pub fn tunable(_attr: TokenStream, item: TokenStream) -> TokenStream {
         .map(|item| to_uci_option(item))
         .collect::<Vec<_>>();
 
+    let uci_option_names = uci_decls
+        .iter()
+        .map(|item| item.ident.to_string().to_lowercase())
+        .collect::<Vec<_>>();
+
+    let uci_atomic_idents = uci_decls
+        .iter()
+        .map(|item| &item.ident)
+        .collect::<Vec<_>>();
+
     let num_uci_opts = uci_opts.len();
 
     let Item::Mod(mod_item) = &ast else { 
@@ -43,6 +53,13 @@ pub fn tunable(_attr: TokenStream, item: TokenStream) -> TokenStream {
             pub const SPSA_UCI_OPTIONS: [UciOption; #num_uci_opts] = [
                 #(#uci_opts),*
             ];
+
+            pub fn set_param(name: &str, value: i32) {
+                match name {
+                    #(#uci_option_names => #uci_atomic_idents.store(value, Ordering::Relaxed),)*
+                    _ => println!("Invalid UCI option: {name}"),
+                };
+            }
         }
     };
 

--- a/simbelmyne/Cargo.toml
+++ b/simbelmyne/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 [dependencies]
 chess = { path = "../chess", package = "simbelmyne-chess" }
 tuner = { path = "../tuner" }
+macros = { path = "../macros" }
 uci = { path = "../uci", package = "simbelmyne-uci" }
 anyhow = "1.0.75"
 colored = "2.0.4"
@@ -20,3 +21,6 @@ clap = { version = "4.4.7", features = ["derive"] }
 itertools = "0.11.0"
 rayon = "1.8.1"
 arrayvec = "0.7.4"
+[features]
+default = ["spsa"]
+spsa = []

--- a/simbelmyne/src/cli/bench.rs
+++ b/simbelmyne/src/cli/bench.rs
@@ -8,7 +8,6 @@ use crate::history_tables::threats::ThreatsHistoryTable;
 use crate::position::Position;
 use crate::transpositions::TTable;
 use crate::time_control::TimeController;
-use crate::search::params::SearchParams;
 
 const NO_DEBUG: bool = false;
 const DEPTH: usize = 14;
@@ -97,14 +96,12 @@ pub fn run_single(fen: &str, depth: usize) -> BenchResult {
     let mut tactical_history = TacticalHistoryTable::boxed();
     let mut conthist = ContHist::boxed();
 
-    let search_params = SearchParams::default();
     let search = position.search::<NO_DEBUG>(
         &mut tt, 
         &mut history, 
         &mut tactical_history,
         &mut conthist,
         &mut tc, 
-        &search_params
     );
 
     BenchResult { 

--- a/simbelmyne/src/cli/mod.rs
+++ b/simbelmyne/src/cli/mod.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
 use clap::Subcommand;
+use crate::spsa::{run_openbench, run_weatherfactory};
+
 use self::{presets::Preset, perft::run_perft, bench::run_bench, tune::run_tune};
 
 pub mod bench;
@@ -10,6 +12,7 @@ pub mod tune;
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
+    /// Run the perft test suite
     Perft {
         /// Set the search depth
         #[arg(short, long, value_name = "DEPTH", default_value = "5")]
@@ -32,8 +35,10 @@ pub enum Command {
         all: bool
     },
 
+    /// Run the bench suite and report the total number of nodes and average nps
     Bench,
 
+    /// Start a tuning run of all the evaluation weights
     Tune {
         #[arg(short, long, value_name = "FILE")]
         file: PathBuf,
@@ -53,6 +58,12 @@ pub enum Command {
         #[arg(short, long, value_name = "ITERATIONS", default_value = "100")]
         interval: usize
     },
+
+    /// Output all tunable UCI options in Openbench's SPSA format
+    Openbench,
+
+    /// Output all tunable UCI options in WeatherFactory's SPSA format
+    WeatherFactory,
 }
 
 impl Command {
@@ -61,6 +72,8 @@ impl Command {
             Command::Perft { depth, fen, preset, all } => run_perft(depth, fen, preset, all)?,
             Command::Tune { file, positions, epochs, output, interval } => run_tune(file, positions, epochs, output, interval),
             Command::Bench => run_bench(),
+            Command::Openbench => run_openbench(),
+            Command::WeatherFactory => run_weatherfactory(), 
         };
 
         Ok(())

--- a/simbelmyne/src/main.rs
+++ b/simbelmyne/src/main.rs
@@ -13,6 +13,7 @@ mod move_picker;
 mod time_control;
 mod tests;
 mod history_tables;
+mod spsa;
 
 #[derive(Parser)]
 #[command(author = "Sam Roelants", version = "0.1", about = "A simple perft tool.", long_about = None)]

--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -44,12 +44,6 @@ use crate::history_tables::threats::ThreatIndex;
 use crate::history_tables::threats::ThreatsHistoryTable;
 use crate::position::Position;
 
-/// Relative piece values used for MVV-LVA scoring.
-#[rustfmt::skip]
-const PIECE_VALS: [i32; PieceType::COUNT] = 
-    // Pawn, Knight, Bishop, Rook, Queen, King
-    [  100,  300,   300,   500, 900,  0];
-
 /// The bonus score used to place killer moves ahead of the other quiet moves
 const KILLER_BONUS: i32 = 30000;
 const COUNTERMOVE_BONUS: i32 = 20000;
@@ -225,7 +219,7 @@ impl<'pos, const ALL: bool> MovePicker<'pos, ALL> {
                     .unwrap();
 
                 // MVV-LVA
-                self.scores[i] += 32 * PIECE_VALS[victim.piece_type()];
+                self.scores[i] += 32 * piece_vals(victim.piece_type());
 
                 // Capthist
                 self.scores[i] += i32::from(tactical_history[victim.piece_type()][idx]);
@@ -503,6 +497,28 @@ impl<'a, const ALL: bool> MovePicker<'a, ALL> {
         ////////////////////////////////////////////////////////////////////////
 
         None
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Helpers
+//
+////////////////////////////////////////////////////////////////////////////////
+
+/// Return the MVV value for a given piece type
+#[inline(always)]
+fn piece_vals(pt: PieceType) -> i32 {
+    use PieceType::*;
+    use crate::search::params::*;
+
+    match pt {
+        Pawn => pawn_value(),
+        Knight => knight_value(),
+        Bishop => bishop_value(),
+        Rook => rook_value(),
+        Queen => queen_value(),
+        King => 0
     }
 }
 

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -41,8 +41,6 @@ use uci::search_info::SearchInfo;
 use uci::search_info::Score as UciScore;
 use uci::engine::UciEngineMessage;
 
-use self::params::SearchParams;
-
 pub(crate) mod params;
 mod zero_window;
 mod negamax;
@@ -59,9 +57,6 @@ pub struct Search<'a> {
 
     // The so-called "selective depth", the deepest ply we've searched
     pub seldepth: usize,
-
-    /// Values for the various search parameters
-    pub search_params: &'a SearchParams,
 
     // The time control for the search
     pub tc: &'a mut TimeController,
@@ -98,7 +93,6 @@ impl<'a> Search<'a> {
         tactical_history: &'a mut TacticalHistoryTable,
         conthist_table: &'a mut ContHist,
         tc: &'a mut TimeController, 
-        search_params: &'a SearchParams
     ) -> Self {
         Self {
             depth,
@@ -109,7 +103,6 @@ impl<'a> Search<'a> {
             history_table,
             tactical_history,
             conthist_table,
-            search_params,
             aborted: false,
             stack: [SearchStackEntry::default(); MAX_DEPTH],
         }
@@ -133,7 +126,6 @@ impl Position {
         tactical_history: &mut TacticalHistoryTable,
         conthist: &mut ContHist,
         tc: &mut TimeController, 
-        search_params: &SearchParams
     ) -> SearchReport {
         let mut depth = 1;
         let mut latest_report = SearchReport::default();
@@ -151,7 +143,6 @@ impl Position {
                 tactical_history,
                 conthist, 
                 tc, 
-                search_params
             );
 
             let score = self.aspiration_search(

--- a/simbelmyne/src/search/aspiration.rs
+++ b/simbelmyne/src/search/aspiration.rs
@@ -19,7 +19,7 @@ use crate::position::Position;
 use crate::evaluate::Score;
 use crate::evaluate::ScoreExt;
 use crate::transpositions::TTable;
-use crate::search::params::params;
+use crate::search::params::*;
 
 use super::Search;
 
@@ -35,10 +35,10 @@ impl Position {
     ) -> Score {
         let mut alpha = Score::MINUS_INF;
         let mut beta = Score::PLUS_INF;
-        let mut width = params.aspiration_base_window();
+        let mut width = aspiration_base_window();
         let mut reduction = 0;
 
-        if depth >= params.aspiration_min_depth() {
+        if depth >= aspiration_min_depth() {
             alpha = Score::max(Score::MINUS_INF, guess - width);
             beta = Score::min(Score::PLUS_INF, guess + width);
         }
@@ -79,7 +79,7 @@ impl Position {
 
             // If the window exceeds the max width, give up and open the window 
             // up completely.
-            if width > params.aspiration_max_window() {
+            if width > aspiration_max_window() {
                 alpha = Score::MINUS_INF;
                 beta = Score::PLUS_INF;
             }

--- a/simbelmyne/src/search/aspiration.rs
+++ b/simbelmyne/src/search/aspiration.rs
@@ -19,6 +19,7 @@ use crate::position::Position;
 use crate::evaluate::Score;
 use crate::evaluate::ScoreExt;
 use crate::transpositions::TTable;
+use crate::search::params::params;
 
 use super::Search;
 
@@ -34,10 +35,10 @@ impl Position {
     ) -> Score {
         let mut alpha = Score::MINUS_INF;
         let mut beta = Score::PLUS_INF;
-        let mut width = search.search_params.aspiration_base_window;
+        let mut width = params.aspiration_base_window();
         let mut reduction = 0;
 
-        if depth >= search.search_params.aspiration_min_depth {
+        if depth >= params.aspiration_min_depth() {
             alpha = Score::max(Score::MINUS_INF, guess - width);
             beta = Score::min(Score::PLUS_INF, guess + width);
         }
@@ -78,7 +79,7 @@ impl Position {
 
             // If the window exceeds the max width, give up and open the window 
             // up completely.
-            if width > search.search_params.aspiration_max_window {
+            if width > params.aspiration_max_window() {
                 alpha = Score::MINUS_INF;
                 beta = Score::PLUS_INF;
             }

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -14,7 +14,7 @@ use chess::movegen::legal_moves::MoveList;
 use chess::movegen::moves::Move;
 use chess::piece::PieceType;
 
-use super::params::params;
+use super::params::*;
 use super::params::lmr_reduction;
 use super::Search;
 use super::params::IIR_THRESHOLD;
@@ -181,14 +181,14 @@ impl Position {
         //
         ////////////////////////////////////////////////////////////////////////
 
-        let futility = params.rfp_margin() * depth as Score
-            + params.rfp_improving_margin() * !improving as Score;
+        let futility = rfp_margin() * depth as Score
+            + rfp_improving_margin() * !improving as Score;
 
         if !PV 
             && !in_root
             && !in_check
             && excluded.is_none()
-            && depth <= params.rfp_threshold()
+            && depth <= rfp_threshold()
             && eval - futility >= beta {
             return (eval + beta) / 2;
         }
@@ -209,11 +209,11 @@ impl Position {
             && !in_root
             && !in_check
             && excluded.is_none()
-            && eval + params.nmp_improving_margin() * improving as Score >= beta
+            && eval + nmp_improving_margin() * improving as Score >= beta
             && self.board.zugzwang_unlikely();
 
         if should_null_prune {
-            let reduction = (params.nmp_base_reduction() + depth / params.nmp_reduction_factor())
+            let reduction = (nmp_base_reduction() + depth / nmp_reduction_factor())
                 .min(depth);
 
             let score = -self
@@ -289,11 +289,11 @@ impl Position {
         ////////////////////////////////////////////////////////////////////////
 
         let se_candidate = tt_entry.filter(|entry| {
-            depth >= params.se_threshold()
+            depth >= se_threshold()
             && !in_root 
             && excluded.is_none() 
             && entry.get_type() != NodeType::Upper
-            && entry.get_depth() >= depth - params.se_tt_delta()
+            && entry.get_depth() >= depth - se_tt_delta()
             && !entry.get_score().is_mate()
         }).and_then(|entry| entry.get_move());
 
@@ -353,14 +353,14 @@ impl Position {
             //
             ////////////////////////////////////////////////////////////////////////
 
-            let futility = params.fp_base()
-                + params.fp_margin() * (lmr_depth as Score)
+            let futility = fp_base()
+                + fp_margin() * (lmr_depth as Score)
                 + 100 * improving as Score;
 
             if move_count > 0 
                 && !PV
                 && !in_check
-                && lmr_depth <= params.fp_threshold()
+                && lmr_depth <= fp_threshold()
                 && eval + futility < alpha {
                 legal_moves.only_good_tacticals = true;
                 continue;
@@ -375,7 +375,7 @@ impl Position {
             //
             ////////////////////////////////////////////////////////////////////
 
-            let see_margin = params.see_quiet_margin() * depth as Score;
+            let see_margin = -see_quiet_margin() * depth as Score;
 
             if legal_moves.stage() > Stage::GoodTacticals
                 && is_quiet
@@ -397,10 +397,10 @@ impl Position {
             //
             ////////////////////////////////////////////////////////////////////
 
-            let lmp_moves = (params.lmp_base()
-                + params.lmp_factor() * depth * depth) / (1 + !improving as usize);
+            let lmp_moves = (lmp_base()
+                + lmp_factor() * depth * depth) / (1 + !improving as usize);
 
-            if depth <= params.lmp_threshold()
+            if depth <= lmp_threshold()
                 && !PV
                 && !in_check
                 && move_count >= lmp_moves {
@@ -433,7 +433,7 @@ impl Position {
 
                 let se_depth = (depth - 1) / 2;
                 let se_beta = Score::max(
-                    tt_score - params.se_margin() * depth as Score,
+                    tt_score - se_margin() * depth as Score,
                     -Score::MATE
                 );
 
@@ -456,8 +456,8 @@ impl Position {
                     // Make sure to keep the total number of double extensions
                     // limited, though.
                     if !PV 
-                    && value + params.double_ext_margin() < se_beta 
-                    && search.stack[ply].double_exts <= params.double_ext_max() {
+                    && value + double_ext_margin() < se_beta 
+                    && search.stack[ply].double_exts <= double_ext_max() {
                         extension += 2;
 
                         search.stack[ply].double_exts += 1;
@@ -504,8 +504,8 @@ impl Position {
                 let mut reduction: i16 = 0;
 
                 // Calculate LMR reduction
-                if depth >= params.lmr_min_depth()
-                    && move_count >= params.lmr_threshold() + PV as usize {
+                if depth >= lmr_min_depth()
+                    && move_count >= lmr_threshold() + PV as usize {
                     // Fetch the base LMR reduction value from the LMR table
                     reduction = lmr_reduction(depth, move_count) as i16;
 

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -1,208 +1,5 @@
 use std::mem::transmute;
-
-use crate::evaluate::Score;
-
-////////////////////////////////////////////////////////////////////////////////
-//
-// SearchParams struct
-//
-// Enables the engine to dynamically set the values for the search parameters,
-// for example through UCI options
-// 
-//
-////////////////////////////////////////////////////////////////////////////////
-
-#[derive(Debug, Clone, Copy)]
-pub struct SearchParams {
-    // Null move pruning
-    nmp_base_reduction: usize,
-    nmp_reduction_factor: usize,
-    nmp_improving_margin: Score,
-
-    // Aspiration windows
-    aspiration_min_depth: usize,
-    aspiration_base_window: Score,
-    aspiration_max_window: Score,
-
-    // Futility pruning
-    fp_threshold: usize,
-    fp_base: Score,
-    fp_margin: Score,
-
-    // Reverse futility pruning
-    rfp_threshold: usize,
-    rfp_margin: Score,
-    rfp_improving_margin: Score,
-
-    // Late move pruning
-    lmp_threshold: usize,
-    lmp_base: usize,
-    lmp_factor: usize,
-
-    // Late move reductions
-    lmr_min_depth: usize,
-    lmr_threshold: usize,
-
-    delta_pruning_margin: Score,
-
-    // SEE pruning
-    see_quiet_margin: Score,
-
-    // Singular extensions
-    se_threshold: usize,
-    se_margin: Score,
-    se_tt_delta: usize,
-
-    double_ext_margin: Score,
-    double_ext_max: u8,
-}
-
-impl SearchParams {
-    pub const fn default() -> Self {
-        Self {
-            // Null move pruning
-            nmp_base_reduction: NMP_BASE_REDUCTION,
-            nmp_reduction_factor: NMP_REDUCTION_FACTOR,
-            nmp_improving_margin: NMP_IMPROVING_MARGIN,
-
-            // Aspiration windows
-            aspiration_min_depth: ASPIRATION_MIN_DEPTH,
-            aspiration_base_window: ASPIRATION_BASE_WINDOW,
-            aspiration_max_window: ASPIRATION_MAX_WINDOW,
-
-            // Futility pruning
-            fp_threshold: FP_THRESHOLD,
-            fp_base: FP_BASE,
-            fp_margin: FP_MARGIN,
-
-            // Reverse futility pruning
-            rfp_threshold: RFP_THRESHOLD,
-            rfp_margin: RFP_MARGIN,
-            rfp_improving_margin: RFP_IMPROVING_MARGIN,
-
-            // Late move pruning
-            lmp_threshold: LMP_THRESHOLD,
-            lmp_base: LMP_BASE,
-            lmp_factor: LMP_FACTOR,
-
-            // Late move reductions
-            lmr_min_depth: LMR_MIN_DEPTH,
-            lmr_threshold: LMR_THRESHOLD,
-
-            delta_pruning_margin: DELTA_PRUNING_MARGIN,
-
-            // SEE pruning
-            see_quiet_margin: SEE_QUIET_MARGIN,
-
-            // Singular extensions
-            se_threshold: SE_THRESHOLD,
-            se_margin: SE_MARGIN,
-            se_tt_delta: SE_TT_DELTA,
-
-            double_ext_margin: DOUBLE_EXT_MARGIN,
-            double_ext_max: DOUBLE_EXT_MAX
-        }
-    }
-
-    pub const fn nmp_base_reduction(&self) -> usize {
-        self.nmp_base_reduction
-    }
-
-    pub const fn nmp_reduction_factor(&self) -> usize {
-        self.nmp_reduction_factor
-    }
-
-    pub const fn nmp_improving_margin(&self) -> Score {
-        self.nmp_improving_margin
-    }
-    
-    pub const fn aspiration_min_depth(&self) -> usize {
-        self.aspiration_min_depth
-    }
-    
-    pub const fn aspiration_base_window(&self) -> Score {
-        self.aspiration_base_window
-    }
-
-    pub const fn aspiration_max_window(&self) -> Score {
-        self.aspiration_max_window
-    }
-
-    pub const fn fp_threshold(&self) -> usize {
-        self.fp_threshold
-    }
-
-    pub const fn fp_base(&self) -> Score {
-        self.fp_base
-    }
-
-    pub const fn fp_margin(&self) -> Score {
-        self.fp_margin
-    }
-
-    pub const fn rfp_threshold(&self) -> usize {
-        self.rfp_threshold
-    }
-
-    pub const fn rfp_margin(&self) -> Score {
-        self.rfp_margin
-    }
-
-    pub const fn rfp_improving_margin(&self) -> Score {
-        self.rfp_improving_margin
-    }
-
-    pub const fn lmp_threshold(&self) -> usize {
-        self.lmp_threshold
-    }
-
-    pub const fn lmp_base(&self) -> usize {
-        self.lmp_base
-    }
-
-    pub const fn lmp_factor(&self) -> usize {
-        self.lmp_factor
-    }
-
-    pub const fn lmr_min_depth(&self) -> usize {
-        self.lmr_min_depth
-    }
-
-    pub const fn lmr_threshold(&self) -> usize {
-        self.lmr_threshold
-    }
-
-    pub const fn delta_pruning_margin(&self) -> Score {
-        self.delta_pruning_margin
-    }
-
-    pub const fn see_quiet_margin(&self) -> Score {
-        self.see_quiet_margin
-    }
-
-    pub const fn se_threshold(&self) -> usize {
-        self.se_threshold
-    }
-
-    pub const fn se_margin(&self) -> Score {
-        self.se_margin
-    }
-
-    pub const fn se_tt_delta(&self) -> usize {
-        self.se_tt_delta
-    }
-
-    pub const fn double_ext_margin(&self) -> Score {
-        self.double_ext_margin
-    }
-
-    pub const fn double_ext_max(&self) -> u8 {
-        self.double_ext_max
-    }
-}
-
-#[allow(non_upper_case_globals)]
-pub const params: SearchParams = SearchParams::default();
+use macros::tunable;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -212,41 +9,10 @@ pub const params: SearchParams = SearchParams::default();
 
 pub const DEFAULT_TT_SIZE: usize = 64;
 pub const MAX_DEPTH: usize = 128;
-
-// Null-move pruning
-pub const NMP_BASE_REDUCTION: usize = 4;
-pub const NMP_REDUCTION_FACTOR: usize = 4;
-pub const NMP_IMPROVING_MARGIN: Score = 70;
-
-// Aspiration search
-pub const ASPIRATION_MIN_DEPTH: usize = 7;
-pub const ASPIRATION_BASE_WINDOW: Score = 19;
-pub const ASPIRATION_MAX_WINDOW: Score = 724;
-
-// Futility pruning
-pub const FP_THRESHOLD: usize = 4;
-pub const FP_BASE: i32 = 64;
-pub const FP_MARGIN: i32 = 71;
-
-// Reverse futility pruning
-pub const RFP_THRESHOLD: usize = 9;
-pub const RFP_MARGIN: Score = 47;
-pub const RFP_IMPROVING_MARGIN: Score = 100;
-
-// Killer moves
 pub const MAX_KILLERS: usize = 2;
-
-// History table
 pub const HIST_AGE_DIVISOR: i16 = 2;
+pub const IIR_THRESHOLD: usize = 4;
 
-// Late move pruning
-pub const LMP_THRESHOLD: usize = 5;
-pub const LMP_BASE: usize = 4;
-pub const LMP_FACTOR: usize = 1;
-
-// Late move reductions
-pub const LMR_MIN_DEPTH: usize = 1;
-pub const LMR_THRESHOLD: usize = 3;
 
 const LMR_TABLE: [[usize; 64]; 64] = unsafe { transmute(*include_bytes!("../../../bins/lmr.bin")) };
 
@@ -254,20 +20,89 @@ pub fn lmr_reduction(depth: usize, move_count: usize) -> usize {
     LMR_TABLE[depth.min(63)][move_count.min(63)]
 }
 
-// Internal iterative reductions
-pub const IIR_THRESHOLD: usize = 4;
+pub use tunable_params::*;
 
-// Delta pruning
-pub const DELTA_PRUNING_MARGIN: Score = 125;
+#[tunable]
+pub mod tunable_params {
+    // Null-move pruning
+    #[uci(min = 0, max = 8, step = 1)]
+    const NMP_BASE_REDUCTION: usize = 4;
 
-// SEE pruning
-pub const SEE_QUIET_MARGIN: Score = -40;
+    #[uci(min = 0, max = 8, step = 1)]
+    const NMP_REDUCTION_FACTOR: usize = 4;
 
-// Singular extensions
-pub const SE_THRESHOLD: usize = 8;
-pub const SE_MARGIN: Score = 2;
-pub const SE_TT_DELTA: usize = 3;
+    #[uci(min = 0, max = 150, step = 10)]
+    const NMP_IMPROVING_MARGIN: i32 = 70;
 
-// Double extensions
-pub const DOUBLE_EXT_MARGIN: Score = 17;
-pub const DOUBLE_EXT_MAX: u8 = 4; 
+    // Aspiration search
+    #[uci(min = 1, max = 10, step = 1)]
+    const ASPIRATION_MIN_DEPTH: usize = 7;
+
+    #[uci(min = 10, max = 50, step = 10)]
+    const ASPIRATION_BASE_WINDOW: i32 = 19;
+
+    #[uci(min = 500, max = 1300, step = 50)]
+    const ASPIRATION_MAX_WINDOW: i32 = 724;
+
+    // Futility pruning
+    #[uci(min = 1, max = 12, step = 1)]
+    const FP_THRESHOLD: usize = 4;
+
+    #[uci(min = 0, max = 150, step = 10)]
+    const FP_BASE: i32 = 64;
+
+    #[uci(min = 0, max = 150, step = 10)]
+    const FP_MARGIN: i32 = 71;
+
+    // Reverse futility pruning
+    #[uci(min = 1, max = 12, step = 1)]
+    const RFP_THRESHOLD: usize = 9;
+
+    #[uci(min = 0, max = 150, step = 10)]
+    const RFP_MARGIN: i32 = 47;
+
+    #[uci(min = 0, max = 150, step = 10)]
+    const RFP_IMPROVING_MARGIN: i32 = 100;
+
+    // Late move pruning
+    #[uci(min = 1, max = 12, step = 1)]
+    const LMP_THRESHOLD: usize = 5;
+
+    #[uci(min = 0, max = 10, step = 1)]
+    const LMP_BASE: usize = 4;
+
+    #[uci(min = 1, max = 5, step = 1)]
+    const LMP_FACTOR: usize = 1;
+
+    // Late move reductions
+    #[uci(min = 1, max = 5, step = 1)]
+    const LMR_MIN_DEPTH: usize = 1;
+
+    #[uci(min = 1, max = 5, step = 1)]
+    const LMR_THRESHOLD: usize = 3;
+
+    // Delta pruning
+    #[uci(min = 100, max = 250, step = 20)]
+    const DELTA_PRUNING_MARGIN: i32 = 125;
+
+    // SEE pruning
+    #[uci(min = 0, max = 200, step = 10)]
+    const SEE_QUIET_MARGIN: i32 = 40;
+
+    // Singular extensions
+    #[uci(min = 1, max = 14, step = 1)]
+    const SE_THRESHOLD: usize = 8;
+
+    #[uci(min = 1, max = 4, step = 1)]
+    const SE_MARGIN: i32 = 2;
+
+    #[uci(min = 1, max = 6, step = 1)]
+    const SE_TT_DELTA: usize = 3;
+
+    // Double extensions
+    #[uci(min = 0, max = 30, step = 5)]
+    const DOUBLE_EXT_MARGIN: i32 = 17;
+
+    #[uci(min = 0, max = 20, step = 2)]
+    const DOUBLE_EXT_MAX: u8 = 4; 
+}

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -15,50 +15,50 @@ use crate::evaluate::Score;
 #[derive(Debug, Clone, Copy)]
 pub struct SearchParams {
     // Null move pruning
-    pub nmp_base_reduction: usize,
-    pub nmp_reduction_factor: usize,
-    pub nmp_improving_margin: Score,
+    nmp_base_reduction: usize,
+    nmp_reduction_factor: usize,
+    nmp_improving_margin: Score,
 
     // Aspiration windows
-    pub aspiration_min_depth: usize,
-    pub aspiration_base_window: Score,
-    pub aspiration_max_window: Score,
+    aspiration_min_depth: usize,
+    aspiration_base_window: Score,
+    aspiration_max_window: Score,
 
     // Futility pruning
-    pub fp_threshold: usize,
-    pub fp_base: Score,
-    pub fp_margin: Score,
+    fp_threshold: usize,
+    fp_base: Score,
+    fp_margin: Score,
 
     // Reverse futility pruning
-    pub rfp_threshold: usize,
-    pub rfp_margin: Score,
-    pub rfp_improving_margin: Score,
+    rfp_threshold: usize,
+    rfp_margin: Score,
+    rfp_improving_margin: Score,
 
     // Late move pruning
-    pub lmp_threshold: usize,
-    pub lmp_base: usize,
-    pub lmp_factor: usize,
+    lmp_threshold: usize,
+    lmp_base: usize,
+    lmp_factor: usize,
 
     // Late move reductions
-    pub lmr_min_depth: usize,
-    pub lmr_threshold: usize,
+    lmr_min_depth: usize,
+    lmr_threshold: usize,
 
-    pub delta_pruning_margin: Score,
+    delta_pruning_margin: Score,
 
     // SEE pruning
-    pub see_quiet_margin: Score,
+    see_quiet_margin: Score,
 
     // Singular extensions
-    pub se_threshold: usize,
-    pub se_margin: Score,
-    pub se_tt_delta: usize,
+    se_threshold: usize,
+    se_margin: Score,
+    se_tt_delta: usize,
 
-    pub double_ext_margin: Score,
-    pub double_ext_max: u8,
+    double_ext_margin: Score,
+    double_ext_max: u8,
 }
 
-impl Default for SearchParams {
-    fn default() -> Self {
+impl SearchParams {
+    pub const fn default() -> Self {
         Self {
             // Null move pruning
             nmp_base_reduction: NMP_BASE_REDUCTION,
@@ -103,7 +103,106 @@ impl Default for SearchParams {
             double_ext_max: DOUBLE_EXT_MAX
         }
     }
+
+    pub const fn nmp_base_reduction(&self) -> usize {
+        self.nmp_base_reduction
+    }
+
+    pub const fn nmp_reduction_factor(&self) -> usize {
+        self.nmp_reduction_factor
+    }
+
+    pub const fn nmp_improving_margin(&self) -> Score {
+        self.nmp_improving_margin
+    }
+    
+    pub const fn aspiration_min_depth(&self) -> usize {
+        self.aspiration_min_depth
+    }
+    
+    pub const fn aspiration_base_window(&self) -> Score {
+        self.aspiration_base_window
+    }
+
+    pub const fn aspiration_max_window(&self) -> Score {
+        self.aspiration_max_window
+    }
+
+    pub const fn fp_threshold(&self) -> usize {
+        self.fp_threshold
+    }
+
+    pub const fn fp_base(&self) -> Score {
+        self.fp_base
+    }
+
+    pub const fn fp_margin(&self) -> Score {
+        self.fp_margin
+    }
+
+    pub const fn rfp_threshold(&self) -> usize {
+        self.rfp_threshold
+    }
+
+    pub const fn rfp_margin(&self) -> Score {
+        self.rfp_margin
+    }
+
+    pub const fn rfp_improving_margin(&self) -> Score {
+        self.rfp_improving_margin
+    }
+
+    pub const fn lmp_threshold(&self) -> usize {
+        self.lmp_threshold
+    }
+
+    pub const fn lmp_base(&self) -> usize {
+        self.lmp_base
+    }
+
+    pub const fn lmp_factor(&self) -> usize {
+        self.lmp_factor
+    }
+
+    pub const fn lmr_min_depth(&self) -> usize {
+        self.lmr_min_depth
+    }
+
+    pub const fn lmr_threshold(&self) -> usize {
+        self.lmr_threshold
+    }
+
+    pub const fn delta_pruning_margin(&self) -> Score {
+        self.delta_pruning_margin
+    }
+
+    pub const fn see_quiet_margin(&self) -> Score {
+        self.see_quiet_margin
+    }
+
+    pub const fn se_threshold(&self) -> usize {
+        self.se_threshold
+    }
+
+    pub const fn se_margin(&self) -> Score {
+        self.se_margin
+    }
+
+    pub const fn se_tt_delta(&self) -> usize {
+        self.se_tt_delta
+    }
+
+    pub const fn double_ext_margin(&self) -> Score {
+        self.double_ext_margin
+    }
+
+    pub const fn double_ext_max(&self) -> u8 {
+        self.double_ext_max
+    }
 }
+
+#[allow(non_upper_case_globals)]
+pub const params: SearchParams = SearchParams::default();
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -134,34 +233,18 @@ pub const RFP_THRESHOLD: usize = 9;
 pub const RFP_MARGIN: Score = 47;
 pub const RFP_IMPROVING_MARGIN: Score = 100;
 
-////////////////////////////////////////////////////////////////////////////////
-//
-// History Tables
-//
-////////////////////////////////////////////////////////////////////////////////
-
 // Killer moves
 pub const MAX_KILLERS: usize = 2;
 
 // History table
 pub const HIST_AGE_DIVISOR: i16 = 2;
 
-////////////////////////////////////////////////////////////////////////////////
-//
 // Late move pruning
-//
-////////////////////////////////////////////////////////////////////////////////
-
 pub const LMP_THRESHOLD: usize = 5;
 pub const LMP_BASE: usize = 4;
 pub const LMP_FACTOR: usize = 1;
 
-////////////////////////////////////////////////////////////////////////////////
-//
 // Late move reductions
-//
-////////////////////////////////////////////////////////////////////////////////
-
 pub const LMR_MIN_DEPTH: usize = 1;
 pub const LMR_THRESHOLD: usize = 3;
 
@@ -171,39 +254,20 @@ pub fn lmr_reduction(depth: usize, move_count: usize) -> usize {
     LMR_TABLE[depth.min(63)][move_count.min(63)]
 }
 
-////////////////////////////////////////////////////////////////////////////////
-//
-// Internal Iterative Reduction
-//
-////////////////////////////////////////////////////////////////////////////////
-
+// Internal iterative reductions
 pub const IIR_THRESHOLD: usize = 4;
 
-////////////////////////////////////////////////////////////////////////////////
-//
 // Delta pruning
-//
-////////////////////////////////////////////////////////////////////////////////
-
 pub const DELTA_PRUNING_MARGIN: Score = 125;
 
-////////////////////////////////////////////////////////////////////////////////
-///
-// Static Exchange Evaluation pruning
-//
-////////////////////////////////////////////////////////////////////////////////
-
+// SEE pruning
 pub const SEE_QUIET_MARGIN: Score = -40;
 
-
-////////////////////////////////////////////////////////////////////////////////
-///
 // Singular extensions
-//
-////////////////////////////////////////////////////////////////////////////////
 pub const SE_THRESHOLD: usize = 8;
 pub const SE_MARGIN: Score = 2;
 pub const SE_TT_DELTA: usize = 3;
 
+// Double extensions
 pub const DOUBLE_EXT_MARGIN: Score = 17;
 pub const DOUBLE_EXT_MAX: u8 = 4; 

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -10,8 +10,7 @@ use crate::evaluate::Score;
 use crate::transpositions::NodeType;
 use crate::transpositions::TTEntry;
 use crate::transpositions::TTable;
-use super::params::params;
-use super::params::MAX_DEPTH;
+use super::params::*;
 use super::HistoryIndex;
 use super::Search;
 
@@ -145,7 +144,7 @@ impl Position {
 
             let futility = eval 
                 + capture_value 
-                + params.delta_pruning_margin();
+                + delta_pruning_margin();
 
             if !in_check && futility <= alpha {
                 continue;

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -10,6 +10,7 @@ use crate::evaluate::Score;
 use crate::transpositions::NodeType;
 use crate::transpositions::TTEntry;
 use crate::transpositions::TTable;
+use super::params::params;
 use super::params::MAX_DEPTH;
 use super::HistoryIndex;
 use super::Search;
@@ -144,7 +145,7 @@ impl Position {
 
             let futility = eval 
                 + capture_value 
-                + search.search_params.delta_pruning_margin;
+                + params.delta_pruning_margin();
 
             if !in_check && futility <= alpha {
                 continue;

--- a/simbelmyne/src/spsa.rs
+++ b/simbelmyne/src/spsa.rs
@@ -1,0 +1,52 @@
+use std::fmt::{Display, Formatter, Result, Error};
+
+use uci::options::{OptionType, UciOption};
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Openbench helper struct
+//
+// Wraps a UCI option and implements display so it prints the UCI option into a
+// OB-compatible format
+//
+////////////////////////////////////////////////////////////////////////////////
+
+pub struct OpenbenchSpsa(UciOption);
+
+const L_RATE: f32 = 0.002;
+
+impl Display for OpenbenchSpsa {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        use OptionType::*;
+        let name = self.0.name;
+        let Spin { min, max, default, step } = self.0.option_type else {
+            return Result::Err(Error)
+        };
+
+        write!(f, "{name}, int, {default}, {min}, {max}, {step}, {L_RATE}")
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Weather-Factory helper struct
+//
+// Wraps a UCI option and implements display so it prints the UCI option into a
+// WeatherFactry-compatible format
+//
+////////////////////////////////////////////////////////////////////////////////
+
+pub struct WeatherFactorySpsa(UciOption);
+
+impl Display for WeatherFactorySpsa {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        use OptionType::*;
+        let name = self.0.name;
+        let Spin { min, max, default, step } = self.0.option_type else {
+            return Result::Err(Error)
+        };
+
+        write!(f, r#""{name}": {{ "value": {default}, "min_value": {min}, "max_value": {max}, "step": {step} }}"#)
+    }
+}
+

--- a/simbelmyne/src/spsa.rs
+++ b/simbelmyne/src/spsa.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter, Result, Error};
-
 use uci::options::{OptionType, UciOption};
+use crate::search::params::SPSA_UCI_OPTIONS;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -11,7 +11,7 @@ use uci::options::{OptionType, UciOption};
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-pub struct OpenbenchSpsa(UciOption);
+pub struct OpenbenchSpsa(pub UciOption);
 
 const L_RATE: f32 = 0.002;
 
@@ -27,6 +27,13 @@ impl Display for OpenbenchSpsa {
     }
 }
 
+// Print out the full set of SPSA-tunable parameters in OB format
+pub fn run_openbench() {
+    for option in SPSA_UCI_OPTIONS {
+        println!("{}", OpenbenchSpsa(option));
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 // Weather-Factory helper struct
@@ -36,7 +43,7 @@ impl Display for OpenbenchSpsa {
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-pub struct WeatherFactorySpsa(UciOption);
+pub struct WeatherFactorySpsa(pub UciOption);
 
 impl Display for WeatherFactorySpsa {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
@@ -50,3 +57,20 @@ impl Display for WeatherFactorySpsa {
     }
 }
 
+// Print out the full set of SPSA-tunable parameters in WF format
+pub fn run_weatherfactory() {
+    println!("{{");
+
+    for (i, option) in SPSA_UCI_OPTIONS.into_iter().enumerate() {
+        print!("{}", WeatherFactorySpsa(option));
+
+        // If there is another option left to go, add a trailing comma
+        if i + 1 < SPSA_UCI_OPTIONS.len() {
+            println!(",");
+        } else {
+            println!("");
+        }
+    }
+
+    println!("}}");
+}

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -27,7 +27,7 @@ use crate::time_control::TimeController;
 use crate::time_control::TimeControlHandle;
 use crate::transpositions::TTable;
 use crate::position::Position;
-use crate::search::params::SPSA_UCI_OPTIONS;
+use crate::search::params::{SPSA_UCI_OPTIONS, set_param};
 
 const DEBUG: bool = true;
 
@@ -197,7 +197,15 @@ impl SearchController {
                                     self.search_thread.resize_tt(size);
                                 },
 
-                                _ => {}
+                                // Treat any other options as search params
+                                // for SPSA purposes.
+                                _ => {
+                                    if let Ok(value) = value.parse::<i32>() {
+                                        set_param(&name, value);
+                                    } else {
+                                        eprintln!("Invalid value {value}");
+                                    }
+                                }
                             }
 
                         }
@@ -221,7 +229,6 @@ enum SearchCommand {
     Search(Position, TimeController),
     Clear,
     ResizeTT(usize),
-    // SetSearchParams(SearchParams),
 }
 
 /// A handle to a long-running thread that's in charge of searching for the best
@@ -273,9 +280,6 @@ impl SearchThread {
                         tt = TTable::with_capacity(size);
                     }
 
-                    // SearchCommand::SetSearchParams(_params) => {
-                    //     search_params = params;
-                    // }
                 }
             }
         });

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -18,7 +18,6 @@ use uci::engine::UciEngineMessage;
 use uci::options::OptionType;
 use uci::options::UciOption;
 use crate::evaluate::pretty_print::print_eval;
-use crate::evaluate::Score;
 use crate::history_tables::capthist::TacticalHistoryTable;
 use crate::history_tables::conthist::ContHist;
 use crate::history_tables::threats::ThreatsHistoryTable;
@@ -47,7 +46,6 @@ use crate::search::params::SE_MARGIN;
 use crate::search::params::SE_THRESHOLD;
 use crate::search::params::SE_TT_DELTA;
 use chess::perft::perft_divide;
-use crate::search::params::SearchParams;
 use crate::time_control::TimeController;
 use crate::time_control::TimeControlHandle;
 use crate::transpositions::TTable;
@@ -77,7 +75,6 @@ pub struct SearchController {
     debug: bool,
     tc_handle: Option<TimeControlHandle>,
     search_thread: SearchThread,
-    search_params: SearchParams,
 }
 
 const UCI_OPTIONS: [UciOption; 25] = [
@@ -314,7 +311,6 @@ impl SearchController {
             debug: false,
             tc_handle: None,
             search_thread: SearchThread::new(),
-            search_params: SearchParams::default(),
         }
     }
 
@@ -422,115 +418,115 @@ impl SearchController {
                                     self.search_thread.resize_tt(size);
                                 },
 
-                                // Internal options, for SPSA tuning
-                                "nmp_base_reduction" => {
-                                    let value: usize = value.parse()?;
-                                    self.search_params.nmp_base_reduction = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "nmp_reduction_factor" => {
-                                    let value: usize = value.parse()?;
-                                    self.search_params.nmp_reduction_factor = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "nmp_improving_margin" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.nmp_improving_margin = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "aspiration_min_depth" => {
-                                    let value: usize = value.parse()?;
-                                    self.search_params.aspiration_min_depth = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "aspiration_base_window" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.aspiration_base_window = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "aspiration_max_window" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.aspiration_max_window = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "fp_threshold" => {
-                                    let value: usize = value.parse()?;
-                                    self.search_params.fp_threshold = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "rfp_threshold" => {
-                                    let value: usize = value.parse()?;
-                                    self.search_params.rfp_threshold = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "rfp_margin" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.rfp_margin = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "lmp_threshold" => {
-                                    let value: usize = value.parse()?;
-                                    self.search_params.lmp_threshold = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "lmr_min_depth" => {
-                                    let value: usize = value.parse()?;
-                                    self.search_params.lmr_min_depth = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "lmr_threshold" => {
-                                    let value: usize = value.parse()?;
-                                    self.search_params.lmr_threshold = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "delta_pruning_margin" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.delta_pruning_margin = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "se_threshold" => {
-                                    let value: usize = value.parse()?;
-                                    self.search_params.se_threshold = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "se_margin" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.se_margin = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "se_tt_delta" => {
-                                    let value: usize = value.parse()?;
-                                    self.search_params.se_tt_delta = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "double_ext_margin" => {
-                                    let value: Score = value.parse()?;
-                                    self.search_params.double_ext_margin = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
-                                "double_ext_max" => {
-                                    let value: u8 = value.parse()?;
-                                    self.search_params.double_ext_max = value;
-                                    self.search_thread.set_search_params(self.search_params.clone())
-                                },
-
+                                // // Internal options, for SPSA tuning
+                                // "nmp_base_reduction" => {
+                                //     let value: usize = value.parse()?;
+                                //     self.search_params.nmp_base_reduction = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "nmp_reduction_factor" => {
+                                //     let value: usize = value.parse()?;
+                                //     self.search_params.nmp_reduction_factor = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "nmp_improving_margin" => {
+                                //     let value: Score = value.parse()?;
+                                //     self.search_params.nmp_improving_margin = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "aspiration_min_depth" => {
+                                //     let value: usize = value.parse()?;
+                                //     self.search_params.aspiration_min_depth = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "aspiration_base_window" => {
+                                //     let value: Score = value.parse()?;
+                                //     self.search_params.aspiration_base_window = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "aspiration_max_window" => {
+                                //     let value: Score = value.parse()?;
+                                //     self.search_params.aspiration_max_window = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "fp_threshold" => {
+                                //     let value: usize = value.parse()?;
+                                //     self.search_params.fp_threshold = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "rfp_threshold" => {
+                                //     let value: usize = value.parse()?;
+                                //     self.search_params.rfp_threshold = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "rfp_margin" => {
+                                //     let value: Score = value.parse()?;
+                                //     self.search_params.rfp_margin = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "lmp_threshold" => {
+                                //     let value: usize = value.parse()?;
+                                //     self.search_params.lmp_threshold = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "lmr_min_depth" => {
+                                //     let value: usize = value.parse()?;
+                                //     self.search_params.lmr_min_depth = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "lmr_threshold" => {
+                                //     let value: usize = value.parse()?;
+                                //     self.search_params.lmr_threshold = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "delta_pruning_margin" => {
+                                //     let value: Score = value.parse()?;
+                                //     self.search_params.delta_pruning_margin = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "se_threshold" => {
+                                //     let value: usize = value.parse()?;
+                                //     self.search_params.se_threshold = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "se_margin" => {
+                                //     let value: Score = value.parse()?;
+                                //     self.search_params.se_margin = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "se_tt_delta" => {
+                                //     let value: usize = value.parse()?;
+                                //     self.search_params.se_tt_delta = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "double_ext_margin" => {
+                                //     let value: Score = value.parse()?;
+                                //     self.search_params.double_ext_margin = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
+                                // "double_ext_max" => {
+                                //     let value: u8 = value.parse()?;
+                                //     self.search_params.double_ext_max = value;
+                                //     self.search_thread.set_search_params(self.search_params.clone())
+                                // },
+                                //
                                 _ => {}
                             }
 
@@ -555,7 +551,7 @@ enum SearchCommand {
     Search(Position, TimeController),
     Clear,
     ResizeTT(usize),
-    SetSearchParams(SearchParams),
+    // SetSearchParams(SearchParams),
 }
 
 /// A handle to a long-running thread that's in charge of searching for the best
@@ -576,7 +572,6 @@ impl SearchThread {
             let mut history = ThreatsHistoryTable::boxed();
             let mut tactical_history = TacticalHistoryTable::boxed();
             let mut conthist = ContHist::boxed();
-            let mut search_params = SearchParams::default();
 
             for msg in rx.iter() {
                 match msg {
@@ -591,7 +586,6 @@ impl SearchThread {
                             &mut tactical_history,
                             &mut conthist,
                             &mut tc, 
-                            &search_params
                         );
 
                     println!("{}", UciEngineMessage::BestMove(report.pv[0]));
@@ -609,9 +603,9 @@ impl SearchThread {
                         tt = TTable::with_capacity(size);
                     }
 
-                    SearchCommand::SetSearchParams(params) => {
-                        search_params = params;
-                    }
+                    // SearchCommand::SetSearchParams(_params) => {
+                    //     search_params = params;
+                    // }
                 }
             }
         });
@@ -633,7 +627,7 @@ impl SearchThread {
         self.tx.send(SearchCommand::ResizeTT(size)).unwrap();
     }
 
-    pub fn set_search_params(&self, search_params: SearchParams) {
-        self.tx.send(SearchCommand::SetSearchParams(search_params)).unwrap();
-    }
+    // pub fn set_search_params(&self, search_params: SearchParams) {
+    //     self.tx.send(SearchCommand::SetSearchParams(search_params)).unwrap();
+    // }
 }

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -21,35 +21,13 @@ use crate::evaluate::pretty_print::print_eval;
 use crate::history_tables::capthist::TacticalHistoryTable;
 use crate::history_tables::conthist::ContHist;
 use crate::history_tables::threats::ThreatsHistoryTable;
-use crate::search::params::ASPIRATION_BASE_WINDOW;
-use crate::search::params::ASPIRATION_MAX_WINDOW;
-use crate::search::params::ASPIRATION_MIN_DEPTH;
 use crate::search::params::DEFAULT_TT_SIZE;
-use crate::search::params::DELTA_PRUNING_MARGIN;
-use crate::search::params::DOUBLE_EXT_MARGIN;
-use crate::search::params::DOUBLE_EXT_MAX;
-use crate::search::params::FP_BASE;
-use crate::search::params::FP_MARGIN;
-use crate::search::params::FP_THRESHOLD;
-use crate::search::params::LMP_BASE;
-use crate::search::params::LMP_FACTOR;
-use crate::search::params::LMP_THRESHOLD;
-use crate::search::params::LMR_MIN_DEPTH;
-use crate::search::params::LMR_THRESHOLD;
-use crate::search::params::NMP_BASE_REDUCTION;
-use crate::search::params::NMP_IMPROVING_MARGIN;
-use crate::search::params::NMP_REDUCTION_FACTOR;
-use crate::search::params::RFP_MARGIN;
-use crate::search::params::RFP_THRESHOLD;
-use crate::search::params::SEE_QUIET_MARGIN;
-use crate::search::params::SE_MARGIN;
-use crate::search::params::SE_THRESHOLD;
-use crate::search::params::SE_TT_DELTA;
 use chess::perft::perft_divide;
 use crate::time_control::TimeController;
 use crate::time_control::TimeControlHandle;
 use crate::transpositions::TTable;
 use crate::position::Position;
+use crate::search::params::SPSA_UCI_OPTIONS;
 
 const DEBUG: bool = true;
 
@@ -77,13 +55,14 @@ pub struct SearchController {
     search_thread: SearchThread,
 }
 
-const UCI_OPTIONS: [UciOption; 25] = [
+const UCI_OPTIONS: [UciOption; 2] = [
     UciOption { 
         name: "Hash",
         option_type: OptionType::Spin { 
             min: 4,
             max: 1024,
-            default: DEFAULT_TT_SIZE as i32
+            default: DEFAULT_TT_SIZE as i32,
+            step: 1
         }
     },
 
@@ -93,212 +72,7 @@ const UCI_OPTIONS: [UciOption; 25] = [
             min: 1,
             max: 1,
             default: 1,
-        }
-    },
-
-    UciOption { 
-        name: "nmp_base_reduction",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 8,
-            default: NMP_BASE_REDUCTION as i32,
-        }
-    },
-
-    UciOption { 
-        name: "nmp_reduction_factor",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 8,
-            default: NMP_REDUCTION_FACTOR as i32, 
-        }
-    },
-
-    UciOption { 
-        name: "nmp_improving_margin",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 150,
-            default: NMP_IMPROVING_MARGIN as i32, 
-        }
-    },
-
-    UciOption { 
-        name: "aspiration_min_depth",
-        option_type: OptionType::Spin {
-            min: 1,
-            max: 8,
-            default: ASPIRATION_MIN_DEPTH as i32,
-        }
-    },
-
-    UciOption { 
-        name: "aspiration_base_window",
-        option_type: OptionType::Spin {
-            min: 10,
-            max: 50, 
-            default: ASPIRATION_BASE_WINDOW as i32,
-        }
-    },
-    UciOption { 
-        name: "aspiration_max_window",
-        option_type: OptionType::Spin {
-            min: 500,  
-            max: 1300, 
-            default: ASPIRATION_MAX_WINDOW as i32,
-        } 
-    },
-
-    UciOption {
-        name: "fp_threshold",
-        option_type: OptionType::Spin {
-            min: 2,
-            max: 12,
-            default: FP_THRESHOLD as i32,
-        }
-    },
-
-    UciOption {
-        name: "fp_base",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 150,
-            default: FP_BASE as i32,
-        }
-    },
-
-    UciOption {
-        name: "fp_margin",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 150,
-            default: FP_MARGIN as i32,
-        }
-    },
-
-    UciOption { 
-        name: "rfp_threshold",
-        option_type: OptionType::Spin {
-            min: 2,
-            max: 12,
-            default: RFP_THRESHOLD as i32,
-        }
-    },
-
-    UciOption {
-        name: "rfp_margin",
-        option_type: OptionType::Spin {
-            min: 20,
-            max: 140,
-            default: RFP_MARGIN
-        }
-    },
-
-    UciOption { 
-        name: "lmp_threshold",
-        option_type: OptionType::Spin {
-            min: 2, 
-            max: 12,
-            default: LMP_THRESHOLD as i32,
-        }
-    },
-
-    UciOption { 
-        name: "lmp_base",
-        option_type: OptionType::Spin {
-            min: 0, 
-            max: 5,
-            default: LMP_BASE as i32,
-        }
-    },
-
-    UciOption { 
-        name: "lmp_factor",
-        option_type: OptionType::Spin {
-            min: 0, 
-            max: 5,
-            default: LMP_FACTOR as i32,
-        }
-    },
-
-    UciOption { 
-        name: "lmr_min_depth", 
-        option_type: OptionType::Spin { 
-            min: 1,
-            max: 5,
-            default: LMR_MIN_DEPTH as i32,
-        }
-    },
-
-    UciOption { 
-        name: "lmr_threshold",
-        option_type: OptionType::Spin {
-            min: 1,
-            max: 5,
-            default: LMR_THRESHOLD as i32,
-        }
-    },
-
-    UciOption { 
-        name: "delta_pruning_margin",
-        option_type: OptionType::Spin {
-            min: 100,
-            max: 250,
-            default: DELTA_PRUNING_MARGIN,
-        }
-    },
-
-    UciOption { 
-        name: "see_quiet_margin",
-        option_type: OptionType::Spin {
-            min: -200,
-            max: 0,
-            default: SEE_QUIET_MARGIN
-        }
-    },
-
-    UciOption { 
-        name: "se_threshold",
-        option_type: OptionType::Spin {
-            min: 1,
-            max: 14,
-            default: SE_THRESHOLD as i32,
-        }
-    },
-
-    UciOption { 
-        name: "se_margin",
-        option_type: OptionType::Spin {
-            min: 1,
-            max: 4,
-            default: SE_MARGIN,
-        }
-    },
-
-    UciOption { 
-        name: "se_tt_delta",
-        option_type: OptionType::Spin {
-            min: 1,
-            max: 6,
-            default: SE_TT_DELTA as i32,
-        }
-    },
-
-    UciOption { 
-        name: "double_ext_margin",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 30,
-            default: DOUBLE_EXT_MARGIN as i32,
-        }
-    },
-
-    UciOption { 
-        name: "double_ext_max",
-        option_type: OptionType::Spin {
-            min: 0,
-            max: 20,
-            default: DOUBLE_EXT_MAX as i32,
+            step: 1
         }
     },
 ];
@@ -342,6 +116,11 @@ impl SearchController {
                             println!("id author {AUTHOR}");
 
                             for option in UCI_OPTIONS {
+                                println!("option {option}");
+                            }
+
+                            #[cfg(feature = "spsa")]
+                            for option in SPSA_UCI_OPTIONS {
                                 println!("option {option}");
                             }
 
@@ -418,115 +197,6 @@ impl SearchController {
                                     self.search_thread.resize_tt(size);
                                 },
 
-                                // // Internal options, for SPSA tuning
-                                // "nmp_base_reduction" => {
-                                //     let value: usize = value.parse()?;
-                                //     self.search_params.nmp_base_reduction = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "nmp_reduction_factor" => {
-                                //     let value: usize = value.parse()?;
-                                //     self.search_params.nmp_reduction_factor = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "nmp_improving_margin" => {
-                                //     let value: Score = value.parse()?;
-                                //     self.search_params.nmp_improving_margin = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "aspiration_min_depth" => {
-                                //     let value: usize = value.parse()?;
-                                //     self.search_params.aspiration_min_depth = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "aspiration_base_window" => {
-                                //     let value: Score = value.parse()?;
-                                //     self.search_params.aspiration_base_window = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "aspiration_max_window" => {
-                                //     let value: Score = value.parse()?;
-                                //     self.search_params.aspiration_max_window = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "fp_threshold" => {
-                                //     let value: usize = value.parse()?;
-                                //     self.search_params.fp_threshold = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "rfp_threshold" => {
-                                //     let value: usize = value.parse()?;
-                                //     self.search_params.rfp_threshold = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "rfp_margin" => {
-                                //     let value: Score = value.parse()?;
-                                //     self.search_params.rfp_margin = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "lmp_threshold" => {
-                                //     let value: usize = value.parse()?;
-                                //     self.search_params.lmp_threshold = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "lmr_min_depth" => {
-                                //     let value: usize = value.parse()?;
-                                //     self.search_params.lmr_min_depth = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "lmr_threshold" => {
-                                //     let value: usize = value.parse()?;
-                                //     self.search_params.lmr_threshold = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "delta_pruning_margin" => {
-                                //     let value: Score = value.parse()?;
-                                //     self.search_params.delta_pruning_margin = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "se_threshold" => {
-                                //     let value: usize = value.parse()?;
-                                //     self.search_params.se_threshold = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "se_margin" => {
-                                //     let value: Score = value.parse()?;
-                                //     self.search_params.se_margin = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "se_tt_delta" => {
-                                //     let value: usize = value.parse()?;
-                                //     self.search_params.se_tt_delta = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "double_ext_margin" => {
-                                //     let value: Score = value.parse()?;
-                                //     self.search_params.double_ext_margin = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
-                                // "double_ext_max" => {
-                                //     let value: u8 = value.parse()?;
-                                //     self.search_params.double_ext_max = value;
-                                //     self.search_thread.set_search_params(self.search_params.clone())
-                                // },
-                                //
                                 _ => {}
                             }
 

--- a/uci/src/client.rs
+++ b/uci/src/client.rs
@@ -82,7 +82,7 @@ impl FromStr for UciClientMessage {
             "setoption" => {
                 let mut parts = remainder.split_whitespace();
                 assert_eq!(parts.next(), Some("name"), "Invalidly formed UCI command");
-                
+
                 let name = parts
                     .by_ref()
                     .take_while(|&word| word != "value")

--- a/uci/src/options.rs
+++ b/uci/src/options.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 #[derive(Debug, Clone)]
 pub enum OptionType {
     Check { default: bool },
-    Spin { min: i32, max: i32, default: i32 },
+    Spin { min: i32, max: i32, default: i32, step: i32 },
     Combo { default: String, allowed: Vec<String> },
     Button,
     String { default: String },
@@ -16,8 +16,8 @@ impl Display for OptionType {
                 write!(f, "type check default {default}")?;
             },
 
-            Self::Spin { min, max, default } => {
-                write!(f, "type spin default {default} min {min} max {max}")?;
+            Self::Spin { min, max, default, .. } => {
+                write!(f, "type spin default {default:<5} min {min:<5} max {max:<5}")?;
             }
 
             Self::Combo { default, allowed }=> {
@@ -49,6 +49,6 @@ pub struct UciOption {
 
 impl Display for UciOption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "name {} {}", self.name, self.option_type)
+        write!(f, "name {:<25} {}", self.name, self.option_type)
     }
 }


### PR DESCRIPTION
Reworks the search param architecture a bit:

Instead of passing a `SearchParams` struct around, we use getter functions that are available everywhere (this means we can easily use them in, e.g., the move picker, without having to pass around the entire struct of search params).

Each variable can be annotated with a `#[uci]` attribute to set the min/max/step values. When compiled with `--features spsa`, those options will appear in the list of UCI options.
The variables are swapped out with atomics, so the getters just read the atomics instead, but we can still update them from the uci prompt.

All of this was an exploration into writing proc macros. Not sure how long we'll keep it, but it works just fine for now, and feels _reasonably_ clean, if not a little magic.