### PR TITLE
Don't copy conthist tables before passing them into `MovePicker::next`

### DIFF
--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -312,21 +312,12 @@ impl Position {
         let mut alpha = alpha;
         let mut local_pv = PVTable::new();
 
-        let oneply_conthist = oneply_hist_idx
-            .map(|ply| search.conthist_table[ply]);
-
-        let twoply_conthist = twoply_hist_idx
-            .map(|ply| search.conthist_table[ply]);
-
-        let fourply_conthist = fourply_hist_idx
-            .map(|ply| search.conthist_table[ply]);
-
         while let Some(mv) = legal_moves.next(
             &search.history_table, 
             &search.tactical_history,
-            oneply_conthist.as_ref(),
-            twoply_conthist.as_ref(),
-            fourply_conthist.as_ref(),
+            oneply_hist_idx.map(|ply| &search.conthist_table[ply]),
+            twoply_hist_idx.map(|ply| &search.conthist_table[ply]),
+            fourply_hist_idx.map(|ply| &search.conthist_table[ply]),
         ) {
             if Some(mv) == excluded {
                 continue;


### PR DESCRIPTION
Not _really_ a bugfix, but very much _not_ what I was intending. Right now, we just copy the entire table and pass a reference into the move picker. What we _really_ want is just a reference to the one, true, conthist table.

The main difference here, apart from performance (?), is that when the move picker actually uses the conthist table (inside `score_quiets()`), we'll have the most up to date history (the values will be different, because we'll have searched all of the tacticals and their entire subtrees)

Only did a regression test, but looks to gain quite nicely.

```
Elo   | 11.69 +- 7.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 3776 W: 1176 L: 1049 D: 1551
Penta | [105, 408, 761, 483, 131]
https://chess.samroelants.com/test/158/
```

bench 7515987