### PR TITLE
Use latest refutation moves from History

### DIFF
--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -257,8 +257,7 @@ impl Position {
         let mut legal_moves = MovePicker::<ALL_MOVES>::new(
             &self,  
             tt_move,
-            search.history.killers[ply],
-            search.history.get_countermove(),
+            ply
         );
 
         ////////////////////////////////////////////////////////////////////////

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -3,7 +3,6 @@ use chess::movegen::moves::Move;
 use chess::see::SEE_VALUES;
 
 use crate::evaluate::ScoreExt;
-use crate::history_tables::killers::Killers;
 use crate::move_picker::MovePicker;
 use crate::position::Position;
 use crate::evaluate::Score;
@@ -106,8 +105,7 @@ impl Position {
         let mut tacticals = MovePicker::<TACTICALS>::new(
             &self,
             tt_move,
-            Killers::new(),
-            None,
+            ply,
         );
 
         tacticals.only_good_tacticals = true;


### PR DESCRIPTION
Pull refutation moves from  the history table, instead of setting them when instantiating the move picker.

bench 7807661

Non-regression
```
Elo   | 2.60 +- 4.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 11344 W: 3394 L: 3309 D: 4641
Penta | [325, 1285, 2362, 1380, 320]
https://chess.samroelants.com/test/167/
```