### PR TITLE
Wdl model

### DIFF
--- a/simbelmyne/Cargo.toml
+++ b/simbelmyne/Cargo.toml
@@ -23,6 +23,6 @@ rayon = "1.8.1"
 arrayvec = "0.7.4"
 
 [features]
-default = []
+default = ["spsa"]
 spsa = []
 wdl = []

--- a/simbelmyne/Cargo.toml
+++ b/simbelmyne/Cargo.toml
@@ -21,6 +21,8 @@ clap = { version = "4.4.7", features = ["derive"] }
 itertools = "0.11.0"
 rayon = "1.8.1"
 arrayvec = "0.7.4"
+
 [features]
-default = ["spsa"]
+default = []
 spsa = []
+wdl = []

--- a/simbelmyne/src/main.rs
+++ b/simbelmyne/src/main.rs
@@ -14,6 +14,7 @@ mod time_control;
 mod tests;
 mod history_tables;
 mod spsa;
+mod wdl;
 
 #[derive(Parser)]
 #[command(author = "Sam Roelants", version = "0.1", about = "A simple perft tool.", long_about = None)]

--- a/simbelmyne/src/main.rs
+++ b/simbelmyne/src/main.rs
@@ -14,7 +14,6 @@ mod time_control;
 mod tests;
 mod history_tables;
 mod spsa;
-mod wdl;
 
 #[derive(Parser)]
 #[command(author = "Sam Roelants", version = "0.1", about = "A simple perft tool.", long_about = None)]

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -21,6 +21,7 @@
 //! search cutting off abruptly. (What if you think you're ahead, but in the 
 //! next turn, your queen gets captured?)
 //!
+use std::io::IsTerminal;
 use std::time::Duration;
 use crate::evaluate::ScoreExt;
 use crate::history_tables::capthist::TacticalHistoryTable;
@@ -39,13 +40,19 @@ use chess::movegen::legal_moves::All;
 use chess::movegen::moves::Move;
 use uci::search_info::SearchInfo;
 use uci::search_info::Score as UciScore;
-use uci::engine::UciEngineMessage;
+use uci::wdl::WdlModel;
 
 pub(crate) mod params;
 mod zero_window;
 mod negamax;
 mod quiescence;
 mod aspiration;
+
+
+const WDL_MODEL: WdlModel = WdlModel {
+    a: [-1687.03839457, 4936.97013397, -4865.11135831, 1907.15036483],
+    b: [-62.39623703, 287.82241928, -379.70952976, 345.03030228],
+};
 
 /// A Search struct holds both the parameters, as well as metrics and results, 
 /// for a given search.
@@ -162,8 +169,26 @@ impl Position {
 
             latest_report = SearchReport::new(&search, tt, pv, score);
 
-            if DEBUG {
-                println!("{}", UciEngineMessage::Info((&latest_report).into()));
+            let wdl_params = WDL_MODEL.params(&self.board);
+            let info = SearchInfo::from(&latest_report);
+
+            // When the output is a terminal, we pretty-print the output
+            // and include WDL stats.
+            if std::io::stdout().is_terminal() {
+                println!("{}", info.to_pretty(wdl_params));
+            } 
+
+            // If we're talking to another process, _and we're not in wdl
+            // mode_, we print UCI compliant output, but with the eval 
+            // rescaled according to the WDL model.
+            else if !cfg!(feature = "wdl") {
+                println!("{}", info.to_uci(wdl_params));
+            } 
+
+            // If we're talking to a process, _and_ we're in WDL mode, we
+            // output the score in internal, unscaled, values.
+            else {
+                println!("{info}");
             }
 
             depth += 1;

--- a/uci/src/engine.rs
+++ b/uci/src/engine.rs
@@ -62,7 +62,7 @@ impl Display for UciEngineMessage {
                 UciOk => write!(f, "{}", "uciok".bright_black()),
                 ReadyOk => write!(f, "{}", "readyok".bright_black()),
                 BestMove(mv) => write!(f, "{} {}", "bestmove".bright_black(), format!("{mv}").italic()),
-                Info(info) => write!(f, "{} {}", "info".bright_black(), info),
+                Info(info) => write!(f, "{}", info),
                 UciOption(option) => write!(f, "{} {}", "option".bright_black(), option),
             }
         } else {

--- a/uci/src/lib.rs
+++ b/uci/src/lib.rs
@@ -6,3 +6,4 @@ pub mod engine;
 pub mod time_control;
 pub mod search_info;
 pub mod options;
+pub mod wdl;

--- a/uci/src/wdl.rs
+++ b/uci/src/wdl.rs
@@ -1,0 +1,57 @@
+use chess::{board::Board, piece::PieceType};
+
+use crate::search_info::Score;
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub struct WdlModel {
+    pub a: [f64; 4],
+    pub b: [f64; 4],
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub struct WdlParams {
+    a: f64,
+    b: f64,
+}
+
+impl WdlModel {
+    pub fn params(&self, board: &Board) -> WdlParams {
+        use PieceType::*;
+
+        let mat = board.piece_bbs[Pawn].count()
+            + 3 * board.piece_bbs[Knight].count()
+            + 3 * board.piece_bbs[Bishop].count()
+            + 5 * board.piece_bbs[Rook].count()
+            + 9 * board.piece_bbs[Queen].count();
+
+        let mat = mat.clamp(17, 78) as f64 / 58.0;
+
+        WdlParams {
+            a: self.a[0]
+                .mul_add(mat, self.a[1])
+                .mul_add(mat, self.a[2])
+                .mul_add(mat, self.a[3]),
+            b: self.b[0]
+                .mul_add(mat, self.b[1])
+                .mul_add(mat, self.b[2])
+                .mul_add(mat, self.b[3]),
+        }
+    }
+}
+
+impl WdlParams {
+    pub fn get_wdl(&self, eval: i32) -> (u64, u64, u64) {
+        let win_rate = 1000.0 / (1.0 + f64::exp(-(eval as f64 - self.a) / self.b));
+        let loss_rate = 1000.0 / (1.0 + f64::exp(-(-eval as f64 - self.a) / self.b));
+        let draw_rate = 1000.0 - win_rate - loss_rate;
+
+        (win_rate as u64, draw_rate as u64, loss_rate as u64)
+    }
+
+    pub fn wdl_normalized(&self, score: Score) -> Score {
+        match score {
+            Score::Cp(s) => Score::Cp((100.0 * s as f64 / self.a) as i32),
+            Score::Mate(n) => Score::Mate(n),
+        }
+    }
+}

--- a/uci/src/wdl.rs
+++ b/uci/src/wdl.rs
@@ -1,7 +1,5 @@
 use chess::{board::Board, piece::PieceType};
 
-use crate::search_info::Score;
-
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub struct WdlModel {
     pub a: [f64; 4],
@@ -41,17 +39,14 @@ impl WdlModel {
 
 impl WdlParams {
     pub fn get_wdl(&self, eval: i32) -> (u64, u64, u64) {
-        let win_rate = 1000.0 / (1.0 + f64::exp(-(eval as f64 - self.a) / self.b));
-        let loss_rate = 1000.0 / (1.0 + f64::exp(-(-eval as f64 - self.a) / self.b));
+        let win_rate = 1000.0 / (1.0 + f64::exp((-eval as f64 + self.a) / self.b));
+        let loss_rate = 1000.0 / (1.0 + f64::exp((eval as f64 + self.a) / self.b));
         let draw_rate = 1000.0 - win_rate - loss_rate;
 
         (win_rate as u64, draw_rate as u64, loss_rate as u64)
     }
 
-    pub fn wdl_normalized(&self, score: Score) -> Score {
-        match score {
-            Score::Cp(s) => Score::Cp((100.0 * s as f64 / self.a) as i32),
-            Score::Mate(n) => Score::Mate(n),
-        }
+    pub fn wdl_normalized(&self, score: i32) -> i32 {
+        (100.0 * score as f64 / self.a) as i32
     }
 }


### PR DESCRIPTION
Fit a logistic WDL model to self-play data and rescale evals in the SF way
(+1.0 eval means 50% chance of winning)

WDL percentages are only rendered when pretty printing, but evals/scores are rescaled in both pretty and uci output.

![scoreWDL](https://github.com/user-attachments/assets/32d9eae4-2911-4be6-8b61-a3a2f90816d5)

Generating data ought to be done through the `wdl` compile flag, which switches off the rescaling and outputs scores in the original, internal units.

I'll probably try and generate more, accurate data at some point (the pgns I used were from an SPSA, lol).