### PR TITLE
Don't clear countermoves between searches

### DIFF
--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -118,7 +118,6 @@ impl Position {
         while depth <= MAX_DEPTH && tc.should_start_search(depth) {
             pv.clear();
             history.clear_all_killers();
-            history.clear_countermoves();
 
             let mut search = Search::new(
                 depth, 


### PR DESCRIPTION
I don't think there's any point to throwing away this information?

---

Yeah, not huge, but hey, I'll take it.

```
Elo   | 2.96 +- 2.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 35692 W: 10017 L: 9713 D: 15962
Penta | [808, 4235, 7505, 4441, 857]
https://chess.samroelants.com/test/171/
```

bench 8080676