### PR TITLE
Add `Position::approx_hash_after` helper

### DIFF
--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -508,10 +508,12 @@ impl Position {
 
             let mut score;
             search.history.push_mv(mv, &self.board);
+            // Instruct the CPU to load the TT entry into the cache ahead of time
+            tt.prefetch(self.approx_hash_after(mv));
+
             let next_position = self.play_move(mv);
 
-            // Instruct the CPU to load the TT entry into the cache ahead of time
-            tt.prefetch(next_position.hash);
+            // tt.prefetch(next_position.hash);
 
             // PV Move
             if move_count == 0 {

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -45,6 +45,7 @@ impl Position {
         }
 
         let in_check = self.board.in_check();
+        let tt_entry = tt.probe(self.hash);
 
         ////////////////////////////////////////////////////////////////////////
         //
@@ -93,7 +94,6 @@ impl Position {
         //
         ////////////////////////////////////////////////////////////////////////
 
-        let tt_entry = tt.probe(self.hash);
         let tt_result = tt_entry.and_then(|entry| {
             entry.try_score(0, alpha, beta, ply)
         });
@@ -157,9 +157,10 @@ impl Position {
             //
             ////////////////////////////////////////////////////////////////////
             search.history.push_mv(mv, &self.board);
+            tt.prefetch(self.approx_hash_after(mv));
 
             let next_position = self.play_move(mv);
-            tt.prefetch(next_position.hash);
+            // tt.prefetch(next_position.hash);
 
             let score = -next_position
                 .quiescence_search(


### PR DESCRIPTION
Add helper that gives an approximate guess of the zobrist hash after
applying a certain move. It's used so we have a cheap way of getting the
zobrist hash ahead of time so we can prefetch the TT entry earlier.

Even if this returns the wrong hash 5% of the time, it just means that
we lose a marginal amount of pre-fetching, but are able to pre-fetch
_much_ earlier.