### PR TITLE
Remove history aging

### DIFF
--- a/simbelmyne/src/history_tables/capthist.rs
+++ b/simbelmyne/src/history_tables/capthist.rs
@@ -25,12 +25,6 @@ impl TacticalHistoryTable {
             Box::from_raw(ptr.cast())
         }
     }
-
-    pub fn age_entries(&mut self) {
-        for mut history in self.tables {
-            history.age_entries();
-        }
-    }
 }
 
 impl Index<PieceType> for TacticalHistoryTable {

--- a/simbelmyne/src/history_tables/corrhist.rs
+++ b/simbelmyne/src/history_tables/corrhist.rs
@@ -25,7 +25,7 @@
 //! Those are clearly the ones that need more correction, because the eval got
 //! it _very_ wrong.
 use chess::piece::Color;
-use crate::{evaluate::Score, search::params::hist_age_divisor, zobrist::ZHash};
+use crate::{evaluate::Score, zobrist::ZHash};
 
 #[derive(Debug)]
 pub struct CorrHistTable {
@@ -48,16 +48,6 @@ impl CorrHistTable {
                 std::alloc::handle_alloc_error(layout);
             }
             Box::from_raw(ptr.cast())
-        }
-    }
-
-    /// Age the entries in the history table by dividing them by
-    /// [HIST_AGE_DIVISOR].
-    pub fn age_entries(&mut self) {
-        for color in 0..Color::COUNT  {
-            for key in 0..Self::SIZE {
-                self.table[color][key].0 /= hist_age_divisor() as i32;
-            }
         }
     }
 

--- a/simbelmyne/src/history_tables/history.rs
+++ b/simbelmyne/src/history_tables/history.rs
@@ -14,7 +14,6 @@
 /// tree the move was played), so we don't flood the scores with moves played at
 /// the leaves, which are inherently less valuable.
 
-use crate::search::params::hist_age_divisor;
 use crate::search::params::hist_bonus_const;
 use crate::search::params::hist_bonus_const_cutoff;
 use crate::search::params::hist_bonus_linear;
@@ -43,16 +42,6 @@ impl HistoryTable {
     pub fn new() -> Self {
         Self {
             scores: [[HistoryScore(0); Square::COUNT]; Piece::COUNT]
-        }
-    }
-
-    /// Reduce the values from previous searches so they don't swamp this 
-    /// search's history values.
-    pub fn age_entries(&mut self) {
-        for piece_idx in 0..Piece::COUNT {
-            for sq_idx in 0..Square::COUNT {
-                self.scores[piece_idx][sq_idx] = HistoryScore(self.scores[piece_idx][sq_idx].0 / hist_age_divisor());
-            }
         }
     }
 }

--- a/simbelmyne/src/history_tables/mod.rs
+++ b/simbelmyne/src/history_tables/mod.rs
@@ -173,10 +173,4 @@ impl History {
     pub fn clear_countermoves(&mut self) {
         self.countermoves = CountermoveTable::boxed();
     }
-
-    pub fn age_entries(&mut self) {
-        self.main_hist.age_entries();
-        self.tact_hist.age_entries();
-        self.corr_hist.age_entries();
-    }
 }

--- a/simbelmyne/src/history_tables/threats.rs
+++ b/simbelmyne/src/history_tables/threats.rs
@@ -23,14 +23,6 @@ impl ThreatsHistoryTable {
             Box::from_raw(ptr.cast())
         }
     }
-
-    pub fn age_entries(&mut self) {
-        for tables in self.tables {
-            for mut table in tables {
-                table.age_entries();
-            }
-        }
-    }
 }
 
 impl Index<ThreatIndex> for ThreatsHistoryTable {

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -226,9 +226,6 @@ pub mod tunable_params {
     #[uci(min = 0, max = 100, step = 10)]
     const HIST_BONUS_QUADRATIC: i16 = 16;
 
-    #[uci(min = 1, max = 4, step = 1)]
-    const HIST_AGE_DIVISOR: i16 = 2;
-
     #[uci(min = 1, max = 16382, step = 100)]
     const HIST_LMR_DIVISOR: i32 = 8191;
 

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -249,7 +249,6 @@ impl SearchThread {
             for msg in rx.iter() {
                 match msg {
                     SearchCommand::Search(position, mut tc) => {
-                        history.age_entries();
                         tt.increment_age();
 
                         let report = position.search::<DEBUG>(


### PR DESCRIPTION
```
Elo   | 6.85 +- 6.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 5530 W: 1617 L: 1508 D: 2405
Penta | [130, 611, 1196, 676, 152]
https://chess.samroelants.com/test/234/
```

Seems like removing aging of different tables individually also gains, so it's not like it's just one table that didn't like the aging.

bench 7202707