### PR TITLE
Simplify pawn structure

### DIFF
--- a/simbelmyne/src/evaluate/pretty_print.rs
+++ b/simbelmyne/src/evaluate/pretty_print.rs
@@ -101,8 +101,8 @@ pub fn print_eval(board: &Board) -> String {
 
     let mut ctx = EvalContext::new(board);
 
-    let white_pawn_structure =  eval.pawn_structure.compute_score::<WHITE>(None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_pawn_structure = -eval.pawn_structure.compute_score::<BLACK>(None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_pawn_structure =  eval.pawn_structure.compute_score::<WHITE>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
+    let black_pawn_structure = -eval.pawn_structure.compute_score::<BLACK>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Pawn structure:", white_pawn_structure, black_pawn_structure));
 
     let white_bishop_pair =  bishop_pair::<WHITE>(&board, None).lerp(eval.game_phase) as f32 / 100.0;

--- a/simbelmyne/src/evaluate/terms.rs
+++ b/simbelmyne/src/evaluate/terms.rs
@@ -408,13 +408,14 @@ pub fn mobility<const WHITE: bool>(board: &Board, pawn_structure: &PawnStructure
     let mut total = S::default();
 
     let us = if WHITE { White } else { Black };
-
+    let our_pawns = board.pawns(us);
+    let their_pawns = board.pawns(!us);
     let their_minors = board.knights(!us) | board.bishops(!us);
     let their_rooks = board.rooks(!us);
     let their_queens = board.queens(!us);
 
     // Pawn threats
-    let pawn_attacks = pawn_structure.pawn_attacks(us);
+    let pawn_attacks = board.pawn_attacks(us);
     ctx.pawn_attacks_on_minors[us] += (pawn_attacks & their_minors).count() as u8;
     ctx.pawn_attacks_on_rooks[us] += (pawn_attacks & their_rooks).count() as u8;
     ctx.pawn_attacks_on_queens[us] += (pawn_attacks & their_queens).count() as u8;
@@ -423,8 +424,8 @@ pub fn mobility<const WHITE: bool>(board: &Board, pawn_structure: &PawnStructure
     let blockers = board.all_occupied();
     let enemy_king_zone = ctx.king_zones[!us];
 
-    let pawn_attacks = pawn_structure.pawn_attacks(!us);
-    let blocked_pawns = pawn_structure.blocked_pawns(us);
+    let pawn_attacks = board.pawn_attacks(!us);
+    let blocked_pawns = our_pawns & their_pawns.backward::<WHITE>();
 
     let mobility_squares = !pawn_attacks & !blocked_pawns;
 

--- a/simbelmyne/src/evaluate/tuner.rs
+++ b/simbelmyne/src/evaluate/tuner.rs
@@ -329,8 +329,8 @@ impl EvalTrace {
             trace.tempo -= 1;
         }
 
-        pawn_structure.compute_score::<WHITE>(Some(&mut trace));
-        pawn_structure.compute_score::<BLACK>(Some(&mut trace));
+        pawn_structure.compute_score::<WHITE>(board, Some(&mut trace));
+        pawn_structure.compute_score::<BLACK>(board, Some(&mut trace));
         bishop_pair::<WHITE>(board, Some(&mut trace));
         bishop_pair::<BLACK>(board, Some(&mut trace));
         rook_open_file::<WHITE>(board, &pawn_structure, Some(&mut trace));


### PR DESCRIPTION
Don't store trivially computable quantities inside pawn structure.

We're hoping to store/fetch these from a cache, so try and make the entries as small as possible.

bench 7142602