### PR TITLE
Add pawn cache

### DIFF
--- a/simbelmyne/src/cli/bench.rs
+++ b/simbelmyne/src/cli/bench.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use uci::time_control::TimeControl;
 
+use crate::evaluate::pawn_cache::PawnCache;
 use crate::history_tables::History;
 use crate::position::Position;
 use crate::transpositions::TTable;
@@ -81,7 +82,7 @@ pub fn run_bench() {
     println!(
         "{} nodes {} nps", 
         total_nodes,
-        total_nodes / total_time.as_secs(),
+        1_000_000_000 * total_nodes / total_time.as_nanos() as u64,
     );
 }
 
@@ -89,11 +90,13 @@ pub fn run_single(fen: &str, depth: usize) -> BenchResult {
     let board = fen.parse().unwrap();
     let position = Position::new(board);
     let mut tt = TTable::with_capacity(16);
+    let mut pc = PawnCache::with_capacity(2);
     let (mut tc, _handle) = TimeController::new(TimeControl::Depth(depth), board);
     let mut history = History::new();
 
     let search = position.search::<NO_DEBUG>(
         &mut tt, 
+        &mut pc,
         &mut history,
         &mut tc, 
     );

--- a/simbelmyne/src/evaluate/pawn_cache.rs
+++ b/simbelmyne/src/evaluate/pawn_cache.rs
@@ -1,0 +1,73 @@
+use chess::bitboard::Bitboard;
+use std::mem::size_of;
+
+use crate::transpositions::ZKey;
+use crate::zobrist::ZHash;
+
+use super::{pawn_structure::PawnStructure, S};
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct PawnCacheEntry {
+    pub hash: ZHash,
+    pub score: S,
+    pub passers: [Bitboard; 2],
+    pub semi_opens: [Bitboard; 2],
+    pub outposts: [Bitboard; 2]
+}
+
+impl PawnCacheEntry {
+    pub fn new(hash: ZHash, pawn_structure: PawnStructure) -> Self {
+        Self {
+            hash,
+            score: pawn_structure.score(),
+            passers: pawn_structure.passed_pawns,
+            semi_opens: pawn_structure.semi_open_files,
+            outposts: pawn_structure.outposts,
+        }
+    }
+}
+
+pub struct PawnCache {
+    table: Vec<PawnCacheEntry>,
+    size: usize,
+}
+
+impl PawnCache {
+    /// Create a new table with the requested capacity in megabytes
+    pub fn with_capacity(mb_size: usize) -> PawnCache {
+        // The number of enties in the TT
+        let size = (mb_size << 20) / size_of::<PawnCacheEntry>();
+        let mut table = Vec::with_capacity(size);
+        table.resize_with(size, PawnCacheEntry::default);
+
+        PawnCache { table, size }
+    }
+
+    pub fn insert(&mut self, entry: PawnCacheEntry) {
+        let key: ZKey = ZKey::from_hash(entry.hash, self.size);
+        let existing = self.table[key.0];
+        self.table[key.0] = entry;
+    }
+
+    // Check whether the hash appears in the transposition table, and return it 
+    // if so.
+    //
+    pub fn probe(&self, hash: ZHash) -> Option<PawnCacheEntry> {
+        let key = ZKey::from_hash(hash, self.size);
+
+        self.table.get(key.0)
+            .filter(|entry| entry.hash == hash)
+            .copied()
+    }
+}
+
+impl From<PawnCacheEntry> for PawnStructure {
+    fn from(value: PawnCacheEntry) -> Self {
+        Self {
+            score: value.score,
+            passed_pawns: value.passers,
+            semi_open_files: value.semi_opens,
+            outposts: value.outposts,
+        }
+    }
+}

--- a/simbelmyne/src/evaluate/pawn_structure.rs
+++ b/simbelmyne/src/evaluate/pawn_structure.rs
@@ -16,18 +16,18 @@ const BLACK: bool = false;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub struct PawnStructure {
     /// The score associated with the pawn structure
-    score: S,
+    pub score: S,
 
     /// Passed pawn bitboards for White and Black
-    passed_pawns: [Bitboard; Color::COUNT],
+    pub passed_pawns: [Bitboard; Color::COUNT],
 
     /// Semi-open file bitboards for White and Black
-    semi_open_files: [Bitboard; Color::COUNT],
+    pub semi_open_files: [Bitboard; Color::COUNT],
 
     /// Outpost squares
     /// Squares that can't be attacked (easily) by opponent pawns, and are
     /// defended by one of our pawns
-    outposts: [Bitboard; Color::COUNT],
+    pub outposts: [Bitboard; Color::COUNT],
 }
 
 impl PawnStructure {
@@ -37,13 +37,8 @@ impl PawnStructure {
         let black_pawns = board.pawns(Black);
 
         // Pawns attacks
-        let white_left_attacks = white_pawns.forward_left::<WHITE>();
-        let white_right_attacks = white_pawns.forward_right::<WHITE>();
-        let white_attacks = white_left_attacks | white_right_attacks;
-
-        let black_left_attacks = black_pawns.forward_left::<BLACK>();
-        let black_right_attacks = black_pawns.forward_right::<BLACK>();
-        let black_attacks = black_left_attacks | black_right_attacks;
+        let white_attacks = board.pawn_attacks(White);
+        let black_attacks = board.pawn_attacks(Black);
 
         // Passed pawns
         let white_passers = white_pawns

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -23,6 +23,7 @@
 //!
 use std::io::IsTerminal;
 use std::time::Duration;
+use crate::evaluate::pawn_cache::PawnCache;
 use crate::evaluate::ScoreExt;
 use crate::history_tables::pv::PVTable;
 use crate::history_tables::History;
@@ -108,6 +109,7 @@ impl Position {
     pub fn search<const DEBUG: bool>(
         &self, 
         tt: &mut TTable, 
+        pawn_cache: &mut PawnCache,
         history: &mut History,
         tc: &mut TimeController, 
     ) -> SearchReport {
@@ -139,6 +141,7 @@ impl Position {
                 search.depth, 
                 latest_report.score, 
                 tt, 
+                pawn_cache,
                 &mut pv, 
                 &mut search
             );

--- a/simbelmyne/src/search/aspiration.rs
+++ b/simbelmyne/src/search/aspiration.rs
@@ -14,6 +14,7 @@
 //! The hope, as always in these things, is that the score is stable enough that
 //! re-searches are minimal, and the time we save in the best-case scenario
 //! more than compensates for the odd re-search.
+use crate::evaluate::pawn_cache::PawnCache;
 use crate::evaluate::Eval;
 use crate::history_tables::pv::PVTable;
 use crate::position::Position;
@@ -31,6 +32,7 @@ impl Position {
         depth: usize, 
         guess: Score, 
         tt: &mut TTable,
+        pawn_cache: &mut PawnCache,
         pv: &mut PVTable,
         search: &mut Search,
     ) -> Score {
@@ -51,6 +53,7 @@ impl Position {
                 alpha,
                 beta,
                 tt,
+                pawn_cache,
                 pv,
                 search,
                 Eval::new(&self.board),

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -2,6 +2,7 @@ use chess::movegen::legal_moves::All;
 use chess::movegen::moves::Move;
 use chess::see::SEE_VALUES;
 
+use crate::evaluate::pawn_cache::PawnCache;
 use crate::evaluate::Eval;
 use crate::evaluate::ScoreExt;
 use crate::move_picker::MovePicker;
@@ -30,6 +31,7 @@ impl Position {
         mut alpha: Score, 
         beta: Score, 
         tt: &mut TTable,
+        pawn_cache: &mut PawnCache,
         search: &mut Search,
         eval_state: Eval,
     ) -> Score {
@@ -162,9 +164,12 @@ impl Position {
             tt.prefetch(self.approx_hash_after(mv));
 
             let next_position = self.play_move(mv);
+
             let next_eval = eval_state.play_move(
                 search.history.indices[ply], 
-                &next_position.board
+                &next_position.board,
+                next_position.pawn_hash,
+                pawn_cache
             );
 
             let score = -next_position
@@ -173,6 +178,7 @@ impl Position {
                     -beta, 
                     -alpha, 
                     tt,
+                    pawn_cache,
                     search,
                     next_eval,
                 );

--- a/simbelmyne/src/search/zero_window.rs
+++ b/simbelmyne/src/search/zero_window.rs
@@ -1,3 +1,4 @@
+use crate::evaluate::pawn_cache::PawnCache;
 use crate::evaluate::{Eval, Score};
 use crate::history_tables::pv::PVTable;
 use crate::position::Position;
@@ -12,11 +13,12 @@ impl Position {
         depth: usize, 
         value: Score, 
         tt: &mut TTable, 
+        pawn_cache: &mut PawnCache,
         pv: &mut PVTable,
         search: &mut Search,
         eval_state: Eval,
         try_null: bool,
     ) -> Score {
-        self.negamax::<false>(ply, depth, value-1, value, tt, pv, search, eval_state, try_null)
+        self.negamax::<false>(ply, depth, value-1, value, tt, pawn_cache, pv, search, eval_state, try_null)
     }
 }

--- a/simbelmyne/src/uci.rs
+++ b/simbelmyne/src/uci.rs
@@ -17,6 +17,7 @@ use uci::client::UciClientMessage;
 use uci::engine::UciEngineMessage;
 use uci::options::OptionType;
 use uci::options::UciOption;
+use crate::evaluate::pawn_cache::PawnCache;
 use crate::evaluate::pretty_print::print_eval;
 use crate::history_tables::History;
 use crate::search::params::DEFAULT_TT_SIZE;
@@ -244,6 +245,7 @@ impl SearchThread {
         std::thread::spawn(move || {
             let mut tt_size = DEFAULT_TT_SIZE;
             let mut tt = TTable::with_capacity(tt_size);
+            let mut pawn_cache = PawnCache::with_capacity(8);
             let mut history = History::new();
 
             for msg in rx.iter() {
@@ -253,6 +255,7 @@ impl SearchThread {
 
                         let report = position.search::<DEBUG>(
                             &mut tt, 
+                            &mut pawn_cache,
                             &mut history,
                             &mut tc, 
                         );


### PR DESCRIPTION
Not super stoked on the implementation. Feels like there should be ways to simplify this further. Also not sure how well this is going to play together with #276.

```
Elo   | 18.57 +- 8.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2584 W: 731 L: 593 D: 1260
Penta | [33, 274, 554, 384, 47]
https://chess.samroelants.com/test/273/
```

bench 7142602