### PR TITLE
Tuner refactors

### DIFF
--- a/simbelmyne/src/cli/tune.rs
+++ b/simbelmyne/src/cli/tune.rs
@@ -1,8 +1,10 @@
-use std::path::PathBuf;
+use std::time::Duration;
+use std::{path::PathBuf, time::Instant};
 use std::fs::File;
 use std::io::Write;
 use crate::evaluate::tuner::EvalWeights;
 use tuner::{Tune, Tuner};
+use colored::Colorize;
 
 pub fn run_tune(file: PathBuf, positions: Option<usize>, epochs: usize, output: Option<PathBuf>, interval: usize) {
     rayon::ThreadPoolBuilder::new()
@@ -10,15 +12,26 @@ pub fn run_tune(file: PathBuf, positions: Option<usize>, epochs: usize, output: 
         .build_global()
         .unwrap();
 
+    let start = Instant::now();
     let weights = EvalWeights::default();
+    eprintln!("Loading input from {}... ", file.to_str().unwrap().blue());
+
     let training_data = weights.load_entries(&file, positions).unwrap();
-    eprintln!("Loaded {} entries", training_data.len());
+    eprintln!(
+        "{} Loaded {} entries", 
+        start.elapsed().pretty(), 
+        training_data.len().to_string().blue()
+    );
 
     let mut tuner = Tuner::new(&weights, training_data);
 
     for epoch in 1..=epochs {
         if epoch % interval == 0 {
-            eprintln!("Epoch {epoch} - Mean Squared Error: {}", tuner.mse());
+            eprintln!(
+                "{} Epoch {epoch} - Mean Squared Error: {}", 
+                start.elapsed().pretty(), 
+                tuner.mse()
+            );
 
             if let Some(ref path) = output {
                 let mut file = File::create(&path).expect("Failed to open file");
@@ -28,5 +41,18 @@ pub fn run_tune(file: PathBuf, positions: Option<usize>, epochs: usize, output: 
         }
 
         tuner.tune();
+    }
+}
+
+trait Pretty {
+    fn pretty(&self) -> String;
+}
+
+impl Pretty for Duration {
+    fn pretty(&self) -> String {
+        let mins = self.as_secs() / 60;
+        let secs = self.as_secs() % 60;
+
+        format!("[{mins:0>2}:{secs:0>2}]").bright_black().to_string()
     }
 }

--- a/simbelmyne/src/cli/tune.rs
+++ b/simbelmyne/src/cli/tune.rs
@@ -5,6 +5,11 @@ use crate::evaluate::tuner::EvalWeights;
 use tuner::{Tune, Tuner};
 
 pub fn run_tune(file: PathBuf, positions: Option<usize>, epochs: usize, output: Option<PathBuf>, interval: usize) {
+    rayon::ThreadPoolBuilder::new()
+        .stack_size(8_000_000) // 8mb
+        .build_global()
+        .unwrap();
+
     let weights = EvalWeights::default();
     let training_data = weights.load_entries(&file, positions).unwrap();
     eprintln!("Loaded {} entries", training_data.len());

--- a/tuner/src/lib.rs
+++ b/tuner/src/lib.rs
@@ -97,7 +97,6 @@ impl<const N: usize> Tuner<N> {
         let momenta: [Score; N] = [Score::default(); N];
         let velocities: [Score; N] = [Score::default(); N];
         let k = optimal_k(&training_data);
-        eprintln!("Optimal k: {k}");
 
         Self {
             k, weights, momenta, velocities, training_data


### PR DESCRIPTION
Nothing major, but I'm still thinking of the bigger stuff.

1. Making the `EvalTrace` a field on the `Eval` struct, so I can simplify a ton of callsites (and I can simplify `EvalTrace::new()` by _a ton_)
2. Write a Derive(Tune) macro that does all of the boilerplate work for us.
  In principle, if we just define the name and number of entries, that should be enough
  for us to spit out implementations for `Default`, `Display`, `EvalTrace`, etc...
3. At some point, I need to incorporate endgame scaling. What will that look like?