### PR TITLE
Use trait monomorphization instead of Option<EvalTrace>

### DIFF
--- a/simbelmyne/src/evaluate/mod.rs
+++ b/simbelmyne/src/evaluate/mod.rs
@@ -50,6 +50,8 @@ use chess::piece::Color;
 use params::TEMPO_BONUS;
 use pawn_cache::PawnCache;
 use pawn_cache::PawnCacheEntry;
+use tuner::NullTrace;
+use tuner::Trace;
 use self::terms::*;
 use self::pawn_structure::PawnStructure;
 pub use util::*;
@@ -159,56 +161,56 @@ impl Eval {
     /// Create a new score for a board
     /// TODO: Make this more efficient? By running over every single term
     /// exactly once. Then we could re-use this to trace, right?
-    pub fn new(board: &Board) -> Self {
+    pub fn new(board: &Board, trace: &mut impl Trace) -> Self {
         let mut eval = Self::default();
 
         for (sq_idx, piece) in board.piece_list.into_iter().enumerate() {
             if let Some(piece) = piece {
                 let sq = Square::from(sq_idx);
                 eval.game_phase += Self::phase_value(piece);
-                eval.material += material(piece, None);
-                eval.psqt += psqt(piece, sq, None);
+                eval.material += material(piece, trace);
+                eval.psqt += psqt(piece, sq, trace);
             }
         }
 
-        eval.pawn_structure         = PawnStructure::new(board);
-        eval.pawn_shield            = pawn_shield::<WHITE>(board, None);
-        eval.pawn_shield           -= pawn_shield::<BLACK>(board, None);
-        eval.pawn_storm             = pawn_storm::<WHITE>(board, None);
-        eval.pawn_storm            -= pawn_storm::<BLACK>(board, None);
-        eval.passers_friendly_king  = passers_friendly_king::<WHITE>(board, &eval.pawn_structure, None);
-        eval.passers_friendly_king -= passers_friendly_king::<BLACK>(board, &eval.pawn_structure, None);
-        eval.passers_enemy_king     = passers_enemy_king::<WHITE>(board, &eval.pawn_structure, None);
-        eval.passers_enemy_king    -= passers_enemy_king::<BLACK>(board, &eval.pawn_structure, None);
-        eval.knight_outposts        = knight_outposts::<WHITE>(board, &eval.pawn_structure, None);
-        eval.knight_outposts       -= knight_outposts::<BLACK>(board, &eval.pawn_structure, None);
-        eval.bishop_outposts        = bishop_outposts::<WHITE>(board, &eval.pawn_structure, None);
-        eval.bishop_outposts       -= bishop_outposts::<BLACK>(board, &eval.pawn_structure, None);
-        eval.bishop_pair            = bishop_pair::<WHITE>(board, None);
-        eval.bishop_pair           -= bishop_pair::<BLACK>(board, None);
-        eval.rook_open_file         = rook_open_file::<WHITE>(board, &eval.pawn_structure, None);
-        eval.rook_open_file        -= rook_open_file::<BLACK>(board, &eval.pawn_structure, None);
-        eval.rook_semiopen_file     = rook_semiopen_file::<WHITE>(board, &eval.pawn_structure, None);
-        eval.rook_semiopen_file    -= rook_semiopen_file::<BLACK>(board, &eval.pawn_structure, None);
-        eval.queen_open_file        = queen_open_file::<WHITE>(board, &eval.pawn_structure, None);
-        eval.queen_open_file       -= queen_open_file::<BLACK>(board, &eval.pawn_structure, None);
-        eval.queen_semiopen_file    = queen_semiopen_file::<WHITE>(board, &eval.pawn_structure, None);
-        eval.queen_semiopen_file   -= queen_semiopen_file::<BLACK>(board, &eval.pawn_structure, None);
-        eval.major_on_seventh       = major_on_seventh::<WHITE>(board, None);
-        eval.major_on_seventh      -= major_on_seventh::<BLACK>(board, None);
-        eval.knight_shelter         = knight_shelter::<WHITE>(board, None);
-        eval.knight_shelter        -= knight_shelter::<BLACK>(board, None);
-        eval.bishop_shelter         = bishop_shelter::<WHITE>(board, None);
-        eval.bishop_shelter        -= bishop_shelter::<BLACK>(board, None);
-        eval.bad_bishops            = bad_bishops::<WHITE>(board, None);
-        eval.bad_bishops           -= bad_bishops::<BLACK>(board, None);
+        eval.pawn_structure         = PawnStructure::new(board, trace);
+        eval.pawn_shield            = pawn_shield::<WHITE>(board, trace);
+        eval.pawn_shield           -= pawn_shield::<BLACK>(board, trace);
+        eval.pawn_storm             = pawn_storm::<WHITE>(board, trace);
+        eval.pawn_storm            -= pawn_storm::<BLACK>(board, trace);
+        eval.passers_friendly_king  = passers_friendly_king::<WHITE>(board, &eval.pawn_structure, trace);
+        eval.passers_friendly_king -= passers_friendly_king::<BLACK>(board, &eval.pawn_structure, trace);
+        eval.passers_enemy_king     = passers_enemy_king::<WHITE>(board, &eval.pawn_structure, trace);
+        eval.passers_enemy_king    -= passers_enemy_king::<BLACK>(board, &eval.pawn_structure, trace);
+        eval.knight_outposts        = knight_outposts::<WHITE>(board, &eval.pawn_structure, trace);
+        eval.knight_outposts       -= knight_outposts::<BLACK>(board, &eval.pawn_structure, trace);
+        eval.bishop_outposts        = bishop_outposts::<WHITE>(board, &eval.pawn_structure, trace);
+        eval.bishop_outposts       -= bishop_outposts::<BLACK>(board, &eval.pawn_structure, trace);
+        eval.bishop_pair            = bishop_pair::<WHITE>(board, trace);
+        eval.bishop_pair           -= bishop_pair::<BLACK>(board, trace);
+        eval.rook_open_file         = rook_open_file::<WHITE>(board, &eval.pawn_structure, trace);
+        eval.rook_open_file        -= rook_open_file::<BLACK>(board, &eval.pawn_structure, trace);
+        eval.rook_semiopen_file     = rook_semiopen_file::<WHITE>(board, &eval.pawn_structure, trace);
+        eval.rook_semiopen_file    -= rook_semiopen_file::<BLACK>(board, &eval.pawn_structure, trace);
+        eval.queen_open_file        = queen_open_file::<WHITE>(board, &eval.pawn_structure, trace);
+        eval.queen_open_file       -= queen_open_file::<BLACK>(board, &eval.pawn_structure, trace);
+        eval.queen_semiopen_file    = queen_semiopen_file::<WHITE>(board, &eval.pawn_structure, trace);
+        eval.queen_semiopen_file   -= queen_semiopen_file::<BLACK>(board, &eval.pawn_structure, trace);
+        eval.major_on_seventh       = major_on_seventh::<WHITE>(board, trace);
+        eval.major_on_seventh      -= major_on_seventh::<BLACK>(board, trace);
+        eval.knight_shelter         = knight_shelter::<WHITE>(board, trace);
+        eval.knight_shelter        -= knight_shelter::<BLACK>(board, trace);
+        eval.bishop_shelter         = bishop_shelter::<WHITE>(board, trace);
+        eval.bishop_shelter        -= bishop_shelter::<BLACK>(board, trace);
+        eval.bad_bishops            = bad_bishops::<WHITE>(board, trace);
+        eval.bad_bishops           -= bad_bishops::<BLACK>(board, trace);
 
         eval
     }
 
     /// Return the total (tapered) score for the position as the sum of the
     /// incremental evaluation terms and the volatile terms.
-    pub fn total(&self, board: &Board) -> Score {
+    pub fn total(&mut self, board: &Board, trace: &mut impl Trace) -> Score {
         // We pass around an EvalContext so expensive information gathered in 
         // some evaluation terms can be shared with other eval terms, instead
         // of recomputing them again.
@@ -236,18 +238,18 @@ impl Eval {
 
         // Compute and add up the "volatile" evaluation terms. These are the 
         // terms that need to get recomputed in every node, anyway.
-        total += connected_rooks::<WHITE>(board, None);
-        total -= connected_rooks::<BLACK>(board, None);
-        total += mobility::<WHITE>(board, &self.pawn_structure, &mut ctx, None);
-        total -= mobility::<BLACK>(board, &self.pawn_structure, &mut ctx, None);
-        total += virtual_mobility::<WHITE>(board, None);
-        total -= virtual_mobility::<BLACK>(board, None);
-        total += king_zone::<WHITE>(&mut ctx, None);
-        total -= king_zone::<BLACK>(&mut ctx, None);
-        total += threats::<WHITE>(&ctx, None);
-        total -= threats::<BLACK>(&ctx, None);
-        total += safe_checks::<WHITE>(board, &ctx, None);
-        total -= safe_checks::<BLACK>(board, &ctx, None);
+        total += connected_rooks::<WHITE>(board, trace);
+        total -= connected_rooks::<BLACK>(board, trace);
+        total += mobility::<WHITE>(board, &self.pawn_structure, &mut ctx, trace);
+        total -= mobility::<BLACK>(board, &self.pawn_structure, &mut ctx, trace);
+        total += virtual_mobility::<WHITE>(board, trace);
+        total -= virtual_mobility::<BLACK>(board, trace);
+        total += king_zone::<WHITE>(&mut ctx, trace);
+        total -= king_zone::<BLACK>(&mut ctx, trace);
+        total += threats::<WHITE>(&ctx, trace);
+        total -= threats::<BLACK>(&ctx, trace);
+        total += safe_checks::<WHITE>(board, &ctx, trace);
+        total -= safe_checks::<BLACK>(board, &ctx, trace);
 
         // Add a side-relative tempo bonus
         // The position should be considered slightly more advantageous for the
@@ -315,8 +317,8 @@ impl Eval {
         pawn_cache: &mut PawnCache
     ) {
         self.game_phase += Self::phase_value(piece);
-        self.material += material(piece, None);
-        self.psqt += psqt(piece, sq, None);
+        self.material += material(piece, &mut NullTrace);
+        self.psqt += psqt(piece, sq, &mut NullTrace);
         self.update_incremental_terms(piece, board, pawn_hash, pawn_cache);
     }
 
@@ -330,8 +332,8 @@ impl Eval {
         pawn_cache: &mut PawnCache
     ) {
         self.game_phase -= Self::phase_value(piece);
-        self.material -= material(piece, None);
-        self.psqt -= psqt(piece, sq, None);
+        self.material -= material(piece, &mut NullTrace);
+        self.psqt -= psqt(piece, sq, &mut NullTrace);
         self.update_incremental_terms(piece, board, pawn_hash, pawn_cache);
     }
 
@@ -348,8 +350,8 @@ impl Eval {
         pawn_hash: ZHash, 
         pawn_cache: &mut PawnCache
     ) {
-        let from_psqt = psqt(piece, from, None);
-        let to_psqt = psqt(piece, to, None);
+        let from_psqt = psqt(piece, from, &mut NullTrace);
+        let to_psqt = psqt(piece, to, &mut NullTrace);
         self.psqt -= from_psqt;
         self.psqt += to_psqt;
         self.update_incremental_terms(piece, board, pawn_hash, pawn_cache);
@@ -376,86 +378,86 @@ impl Eval {
                 self.pawn_structure = if let Some(entry) = pawn_cache.probe(pawn_hash) {
                     entry.into()
                 } else {
-                    let pawn_structure = PawnStructure::new(board);
+                    let pawn_structure = PawnStructure::new(board, &mut NullTrace);
                     pawn_cache.insert(PawnCacheEntry::new(pawn_hash, pawn_structure));
                     pawn_structure
                 };
 
-                self.pawn_shield  = pawn_shield::<WHITE>(board, None);
-                self.pawn_shield -= pawn_shield::<BLACK>(board, None);
-                self.pawn_storm  = pawn_storm::<WHITE>(board, None);
-                self.pawn_storm -= pawn_storm::<BLACK>(board, None);
-                self.passers_friendly_king  = passers_friendly_king::<WHITE>(board, &self.pawn_structure, None);
-                self.passers_friendly_king -= passers_friendly_king::<BLACK>(board, &self.pawn_structure, None);
-                self.passers_enemy_king  = passers_enemy_king::<WHITE>(board, &self.pawn_structure, None);
-                self.passers_enemy_king -= passers_enemy_king::<BLACK>(board, &self.pawn_structure, None);
-                self.knight_outposts  = knight_outposts::<WHITE>(board, &self.pawn_structure, None);
-                self.knight_outposts -= knight_outposts::<BLACK>(board, &self.pawn_structure, None);
-                self.bishop_outposts  = bishop_outposts::<WHITE>(board, &self.pawn_structure, None);
-                self.bishop_outposts -= bishop_outposts::<BLACK>(board, &self.pawn_structure, None);
-                self.knight_shelter  = knight_shelter::<WHITE>(board, None);
-                self.knight_shelter -= knight_shelter::<BLACK>(board, None);
-                self.bishop_shelter  = bishop_shelter::<WHITE>(board, None);
-                self.bishop_shelter -= bishop_shelter::<BLACK>(board, None);
-                self.rook_open_file  = rook_open_file::<WHITE>(board, &self.pawn_structure, None);
-                self.rook_open_file -= rook_open_file::<BLACK>(board, &self.pawn_structure, None);
-                self.rook_semiopen_file  = rook_semiopen_file::<WHITE>(board, &self.pawn_structure, None);
-                self.rook_semiopen_file -= rook_semiopen_file::<BLACK>(board, &self.pawn_structure, None);
-                self.queen_open_file  = queen_open_file::<WHITE>(board, &self.pawn_structure, None);
-                self.queen_open_file -= queen_open_file::<BLACK>(board, &self.pawn_structure, None);
-                self.queen_semiopen_file  = queen_semiopen_file::<WHITE>(board, &self.pawn_structure, None);
-                self.queen_semiopen_file -= queen_semiopen_file::<BLACK>(board, &self.pawn_structure, None);
-                self.major_on_seventh  = major_on_seventh::<WHITE>(board, None);
-                self.major_on_seventh -= major_on_seventh::<BLACK>(board, None);
-                self.bad_bishops  = bad_bishops::<WHITE>(board, None);
-                self.bad_bishops -= bad_bishops::<BLACK>(board, None);
+                self.pawn_shield  = pawn_shield::<WHITE>(board, &mut NullTrace);
+                self.pawn_shield -= pawn_shield::<BLACK>(board, &mut NullTrace);
+                self.pawn_storm  = pawn_storm::<WHITE>(board, &mut NullTrace);
+                self.pawn_storm -= pawn_storm::<BLACK>(board, &mut NullTrace);
+                self.passers_friendly_king  = passers_friendly_king::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.passers_friendly_king -= passers_friendly_king::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
+                self.passers_enemy_king  = passers_enemy_king::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.passers_enemy_king -= passers_enemy_king::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
+                self.knight_outposts  = knight_outposts::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.knight_outposts -= knight_outposts::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
+                self.bishop_outposts  = bishop_outposts::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.bishop_outposts -= bishop_outposts::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
+                self.knight_shelter  = knight_shelter::<WHITE>(board, &mut NullTrace);
+                self.knight_shelter -= knight_shelter::<BLACK>(board, &mut NullTrace);
+                self.bishop_shelter  = bishop_shelter::<WHITE>(board, &mut NullTrace);
+                self.bishop_shelter -= bishop_shelter::<BLACK>(board, &mut NullTrace);
+                self.rook_open_file  = rook_open_file::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.rook_open_file -= rook_open_file::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
+                self.rook_semiopen_file  = rook_semiopen_file::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.rook_semiopen_file -= rook_semiopen_file::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
+                self.queen_open_file  = queen_open_file::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.queen_open_file -= queen_open_file::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
+                self.queen_semiopen_file  = queen_semiopen_file::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.queen_semiopen_file -= queen_semiopen_file::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
+                self.major_on_seventh  = major_on_seventh::<WHITE>(board, &mut NullTrace);
+                self.major_on_seventh -= major_on_seventh::<BLACK>(board, &mut NullTrace);
+                self.bad_bishops  = bad_bishops::<WHITE>(board, &mut NullTrace);
+                self.bad_bishops -= bad_bishops::<BLACK>(board, &mut NullTrace);
             },
 
             Knight => {
-                self.knight_outposts  = knight_outposts::<WHITE>(board, &self.pawn_structure, None);
-                self.knight_outposts -= knight_outposts::<BLACK>(board, &self.pawn_structure, None);
-                self.knight_shelter  = knight_shelter::<WHITE>(board, None);
-                self.knight_shelter -= knight_shelter::<BLACK>(board, None);
+                self.knight_outposts  = knight_outposts::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.knight_outposts -= knight_outposts::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
+                self.knight_shelter  = knight_shelter::<WHITE>(board, &mut NullTrace);
+                self.knight_shelter -= knight_shelter::<BLACK>(board, &mut NullTrace);
             },
 
             Bishop => {
-                self.bishop_pair  = bishop_pair::<WHITE>(board, None);
-                self.bishop_pair -= bishop_pair::<BLACK>(board, None);
-                self.bishop_outposts  = bishop_outposts::<WHITE>(board, &self.pawn_structure, None);
-                self.bishop_outposts -= bishop_outposts::<BLACK>(board, &self.pawn_structure, None);
-                self.bishop_shelter  = bishop_shelter::<WHITE>(board, None);
-                self.bishop_shelter -= bishop_shelter::<BLACK>(board, None);
-                self.bad_bishops  = bad_bishops::<WHITE>(board, None);
-                self.bad_bishops -= bad_bishops::<BLACK>(board, None);
+                self.bishop_pair  = bishop_pair::<WHITE>(board, &mut NullTrace);
+                self.bishop_pair -= bishop_pair::<BLACK>(board, &mut NullTrace);
+                self.bishop_outposts  = bishop_outposts::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.bishop_outposts -= bishop_outposts::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
+                self.bishop_shelter  = bishop_shelter::<WHITE>(board, &mut NullTrace);
+                self.bishop_shelter -= bishop_shelter::<BLACK>(board, &mut NullTrace);
+                self.bad_bishops  = bad_bishops::<WHITE>(board, &mut NullTrace);
+                self.bad_bishops -= bad_bishops::<BLACK>(board, &mut NullTrace);
             },
 
             Rook => {
-                self.rook_open_file  = rook_open_file::<WHITE>(board, &self.pawn_structure, None);
-                self.rook_open_file -= rook_open_file::<BLACK>(board, &self.pawn_structure, None);
-                self.rook_semiopen_file  = rook_semiopen_file::<WHITE>(board, &self.pawn_structure, None);
-                self.rook_semiopen_file -= rook_semiopen_file::<BLACK>(board, &self.pawn_structure, None);
-                self.major_on_seventh  = major_on_seventh::<WHITE>(board, None);
-                self.major_on_seventh -= major_on_seventh::<BLACK>(board, None);
+                self.rook_open_file  = rook_open_file::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.rook_open_file -= rook_open_file::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
+                self.rook_semiopen_file  = rook_semiopen_file::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.rook_semiopen_file -= rook_semiopen_file::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
+                self.major_on_seventh  = major_on_seventh::<WHITE>(board, &mut NullTrace);
+                self.major_on_seventh -= major_on_seventh::<BLACK>(board, &mut NullTrace);
             },
 
             Queen => {
-                self.queen_open_file  = queen_open_file::<WHITE>(board, &self.pawn_structure, None);
-                self.queen_open_file -= queen_open_file::<BLACK>(board, &self.pawn_structure, None);
-                self.queen_semiopen_file  = queen_semiopen_file::<WHITE>(board, &self.pawn_structure, None);
-                self.queen_semiopen_file -= queen_semiopen_file::<BLACK>(board, &self.pawn_structure, None);
-                self.major_on_seventh  = major_on_seventh::<WHITE>(board, None);
-                self.major_on_seventh -= major_on_seventh::<BLACK>(board, None);
+                self.queen_open_file  = queen_open_file::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.queen_open_file -= queen_open_file::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
+                self.queen_semiopen_file  = queen_semiopen_file::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.queen_semiopen_file -= queen_semiopen_file::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
+                self.major_on_seventh  = major_on_seventh::<WHITE>(board, &mut NullTrace);
+                self.major_on_seventh -= major_on_seventh::<BLACK>(board, &mut NullTrace);
             },
 
             King => {
-                self.pawn_shield  = pawn_shield::<WHITE>(board, None);
-                self.pawn_shield -= pawn_shield::<BLACK>(board, None);
-                self.pawn_storm  = pawn_storm::<WHITE>(board, None);
-                self.pawn_storm -= pawn_storm::<BLACK>(board, None);
-                self.passers_friendly_king  = passers_friendly_king::<WHITE>(board, &self.pawn_structure, None);
-                self.passers_friendly_king -= passers_friendly_king::<BLACK>(board, &self.pawn_structure, None);
-                self.passers_enemy_king  = passers_enemy_king::<WHITE>(board, &self.pawn_structure, None);
-                self.passers_enemy_king -= passers_enemy_king::<BLACK>(board, &self.pawn_structure, None);
+                self.pawn_shield  = pawn_shield::<WHITE>(board, &mut NullTrace);
+                self.pawn_shield -= pawn_shield::<BLACK>(board, &mut NullTrace);
+                self.pawn_storm  = pawn_storm::<WHITE>(board, &mut NullTrace);
+                self.pawn_storm -= pawn_storm::<BLACK>(board, &mut NullTrace);
+                self.passers_friendly_king  = passers_friendly_king::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.passers_friendly_king -= passers_friendly_king::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
+                self.passers_enemy_king  = passers_enemy_king::<WHITE>(board, &self.pawn_structure, &mut NullTrace);
+                self.passers_enemy_king -= passers_enemy_king::<BLACK>(board, &self.pawn_structure, &mut NullTrace);
             },
         }
     }

--- a/simbelmyne/src/evaluate/pretty_print.rs
+++ b/simbelmyne/src/evaluate/pretty_print.rs
@@ -3,7 +3,7 @@ use colored::Colorize;
 
 use crate::evaluate::terms::{material, psqt};
 
-use super::{terms::{bishop_pair, connected_rooks, king_zone, major_on_seventh, mobility, passers_enemy_king, passers_friendly_king, pawn_shield, pawn_storm, queen_open_file, queen_semiopen_file, rook_open_file, rook_semiopen_file, virtual_mobility}, Eval, EvalContext};
+use super::{terms::{bishop_pair, connected_rooks, king_zone, major_on_seventh, mobility, passers_enemy_king, passers_friendly_king, pawn_shield, pawn_storm, queen_open_file, queen_semiopen_file, rook_open_file, rook_semiopen_file, virtual_mobility}, tuner::NullTrace, Eval, EvalContext};
 
 const WHITE: bool = true;
 const BLACK: bool = false;
@@ -36,7 +36,7 @@ fn blank_line(rank: usize) -> String {
 }
 
 pub fn print_eval(board: &Board) -> String {
-    let eval = Eval::new(board);
+    let mut eval = Eval::new(board, &mut NullTrace);
 
     let mut lines: Vec<String> = vec![];
     lines.push("      a      b      c      d      e      f      g      h    ".to_string());
@@ -74,7 +74,7 @@ pub fn print_eval(board: &Board) -> String {
             let fg = if (rank + file) % 2 == 0 { "black" } else { "white" };
             let score = if let Some(piece) = board.get_at(sq) {
                 // Get score for piece
-                let score = material(piece, None) + psqt(piece, sq, None);
+                let score = material(piece, &mut NullTrace) + psqt(piece, sq, &mut NullTrace);
                 let pawn_score = score.lerp(eval.game_phase) as f32 / 100.0;
 
                 format!("{:.2}", pawn_score)
@@ -101,69 +101,69 @@ pub fn print_eval(board: &Board) -> String {
 
     let mut ctx = EvalContext::new(board);
 
-    let white_pawn_structure =  eval.pawn_structure.compute_score::<WHITE>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_pawn_structure = -eval.pawn_structure.compute_score::<BLACK>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_pawn_structure =  eval.pawn_structure.compute_score::<WHITE>(&board, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
+    let black_pawn_structure = -eval.pawn_structure.compute_score::<BLACK>(&board, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Pawn structure:", white_pawn_structure, black_pawn_structure));
 
-    let white_bishop_pair =  bishop_pair::<WHITE>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_bishop_pair = -bishop_pair::<BLACK>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_bishop_pair =  bishop_pair::<WHITE>(&board, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
+    let black_bishop_pair = -bishop_pair::<BLACK>(&board, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Bishop pair", white_bishop_pair, black_bishop_pair));
 
-    let white_rook_open_file =  rook_open_file::<WHITE>(&board, &eval.pawn_structure, None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_rook_open_file = -rook_open_file::<BLACK>(&board, &eval.pawn_structure, None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_rook_open_file =  rook_open_file::<WHITE>(&board, &eval.pawn_structure, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
+    let black_rook_open_file = -rook_open_file::<BLACK>(&board, &eval.pawn_structure, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Rook on open file:", white_rook_open_file, black_rook_open_file));
 
-    let white_rook_semiopen_file =  rook_semiopen_file::<WHITE>(&board, &eval.pawn_structure, None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_rook_semiopen_file = -rook_semiopen_file::<BLACK>(&board, &eval.pawn_structure, None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_rook_semiopen_file =  rook_semiopen_file::<WHITE>(&board, &eval.pawn_structure, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
+    let black_rook_semiopen_file = -rook_semiopen_file::<BLACK>(&board, &eval.pawn_structure, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Rook on semiopen file:", white_rook_semiopen_file, black_rook_semiopen_file));
 
-    let white_connected_rooks =  connected_rooks::<WHITE>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_connected_rooks = -connected_rooks::<BLACK>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_connected_rooks =  connected_rooks::<WHITE>(&board, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
+    let black_connected_rooks = -connected_rooks::<BLACK>(&board, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Connected rooks:", white_connected_rooks, black_connected_rooks));
 
-    let white_queen_open_file =  queen_open_file::<WHITE>(&board, &eval.pawn_structure, None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_queen_open_file = -queen_open_file::<BLACK>(&board, &eval.pawn_structure, None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_queen_open_file =  queen_open_file::<WHITE>(&board, &eval.pawn_structure, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
+    let black_queen_open_file = -queen_open_file::<BLACK>(&board, &eval.pawn_structure, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Queen on open file:", white_queen_open_file, black_queen_open_file));
 
-    let white_queen_semiopen_file =  queen_semiopen_file::<WHITE>(&board, &eval.pawn_structure, None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_queen_semiopen_file = -queen_semiopen_file::<BLACK>(&board, &eval.pawn_structure, None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_queen_semiopen_file =  queen_semiopen_file::<WHITE>(&board, &eval.pawn_structure, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
+    let black_queen_semiopen_file = -queen_semiopen_file::<BLACK>(&board, &eval.pawn_structure, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Queen on semiopen file:", white_queen_semiopen_file, black_queen_semiopen_file));
 
-    let white_major_on_7th =  major_on_seventh::<WHITE>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_major_on_7th = -major_on_seventh::<BLACK>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_major_on_7th =  major_on_seventh::<WHITE>(&board, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
+    let black_major_on_7th = -major_on_seventh::<BLACK>(&board, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Major on 7th:", white_major_on_7th, black_major_on_7th));
 
-    let white_pawn_shield =  pawn_shield::<WHITE>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_pawn_shield = -pawn_shield::<BLACK>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_pawn_shield =  pawn_shield::<WHITE>(&board, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
+    let black_pawn_shield = -pawn_shield::<BLACK>(&board, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Pawn shield:", white_pawn_shield, black_pawn_shield));
 
-    let white_pawn_storm =  pawn_storm::<WHITE>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_pawn_storm = -pawn_storm::<BLACK>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_pawn_storm =  pawn_storm::<WHITE>(&board, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
+    let black_pawn_storm = -pawn_storm::<BLACK>(&board, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Pawn storm:", white_pawn_storm, black_pawn_storm));
 
-    let white_passers_friendly_king =  passers_friendly_king::<WHITE>(&board, &eval.pawn_structure, None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_passers_friendly_king = -passers_friendly_king::<BLACK>(&board, &eval.pawn_structure, None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_passers_friendly_king =  passers_friendly_king::<WHITE>(&board, &eval.pawn_structure, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
+    let black_passers_friendly_king = -passers_friendly_king::<BLACK>(&board, &eval.pawn_structure, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Passers - Friendly king:", white_passers_friendly_king, black_passers_friendly_king));
 
-    let white_passers_enemy_king =  passers_enemy_king::<WHITE>(&board, &eval.pawn_structure, None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_passers_enemy_king = -passers_enemy_king::<BLACK>(&board, &eval.pawn_structure, None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_passers_enemy_king =  passers_enemy_king::<WHITE>(&board, &eval.pawn_structure, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
+    let black_passers_enemy_king = -passers_enemy_king::<BLACK>(&board, &eval.pawn_structure, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Passers - Enemy king:", white_passers_enemy_king, black_passers_enemy_king));
 
-    let white_mobility =  mobility::<WHITE>(&board, &eval.pawn_structure, &mut ctx, None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_mobility = -mobility::<BLACK>(&board, &eval.pawn_structure, &mut ctx, None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_mobility =  mobility::<WHITE>(&board, &eval.pawn_structure, &mut ctx, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
+    let black_mobility = -mobility::<BLACK>(&board, &eval.pawn_structure, &mut ctx, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Mobility:", white_mobility, black_mobility));
 
-    let white_virtual_mobility =  virtual_mobility::<WHITE>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_virtual_mobility = -virtual_mobility::<BLACK>(&board, None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_virtual_mobility =  virtual_mobility::<WHITE>(&board, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
+    let black_virtual_mobility = -virtual_mobility::<BLACK>(&board, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "Virtual mobility:", white_virtual_mobility, black_virtual_mobility));
 
-    let white_king_zone =  king_zone::<WHITE>(&mut ctx, None).lerp(eval.game_phase) as f32 / 100.0;
-    let black_king_zone = -king_zone::<BLACK>(&mut ctx, None).lerp(eval.game_phase) as f32 / 100.0;
+    let white_king_zone =  king_zone::<WHITE>(&mut ctx, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
+    let black_king_zone = -king_zone::<BLACK>(&mut ctx, &mut NullTrace).lerp(eval.game_phase) as f32 / 100.0;
     lines.push(format!("{:<25} {:>7.2} {:>7.2}", "King zone:", white_king_zone, black_king_zone));
 
     lines.push("".to_string());
 
-    lines.push(format!("Total: {}", eval.total(&board)));
+    lines.push(format!("Total: {}", eval.total(&board, &mut NullTrace)));
 
     lines.join("\n")
 }

--- a/simbelmyne/src/search/aspiration.rs
+++ b/simbelmyne/src/search/aspiration.rs
@@ -15,6 +15,7 @@
 //! re-searches are minimal, and the time we save in the best-case scenario
 //! more than compensates for the odd re-search.
 use crate::evaluate::pawn_cache::PawnCache;
+use crate::evaluate::tuner::NullTrace;
 use crate::evaluate::Eval;
 use crate::history_tables::pv::PVTable;
 use crate::position::Position;
@@ -56,7 +57,7 @@ impl Position {
                 pawn_cache,
                 pv,
                 search,
-                Eval::new(&self.board),
+                Eval::new(&self.board, &mut NullTrace),
                 false
             );
 

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -1,4 +1,5 @@
 use crate::evaluate::pawn_cache::PawnCache;
+use crate::evaluate::tuner::NullTrace;
 use crate::evaluate::Eval;
 use crate::history_tables::history::HistoryScore;
 use crate::history_tables::pv::PVTable;
@@ -33,7 +34,7 @@ impl Position {
         pawn_cache: &mut PawnCache,
         pv: &mut PVTable,
         search: &mut Search,
-        eval_state: Eval,
+        mut eval_state: Eval,
         try_null: bool,
     ) -> Score {
         if search.aborted {
@@ -136,7 +137,7 @@ impl Position {
         } else if let Some(entry) = tt_entry {
             entry.get_eval()
         } else {
-            eval_state.total(&self.board)
+            eval_state.total(&self.board, &mut NullTrace)
         };
 
         let static_eval = if excluded.is_some() {

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -2,6 +2,7 @@ use chess::movegen::legal_moves::All;
 use chess::movegen::moves::Move;
 
 use crate::evaluate::pawn_cache::PawnCache;
+use crate::evaluate::tuner::NullTrace;
 use crate::evaluate::Eval;
 use crate::evaluate::ScoreExt;
 use crate::move_picker::MovePicker;
@@ -32,7 +33,7 @@ impl Position {
         tt: &mut TTable,
         pawn_cache: &mut PawnCache,
         search: &mut Search,
-        eval_state: Eval,
+        mut eval_state: Eval,
     ) -> Score {
         if !search.tc.should_continue(search.nodes) {
             search.aborted = true;
@@ -67,7 +68,7 @@ impl Position {
             // let idx = search.history.indices[ply-1];
             // let new_eval = eval_state.play_move(idx, &self.board);
             // search.stack[ply].incremental_eval = Some(new_eval);
-            eval_state.total(&self.board)
+            eval_state.total(&self.board, &mut NullTrace)
         };
 
         let static_eval = if in_check {


### PR DESCRIPTION
Ended up going for the trait + generic method. I've seen this approach used in Cheers, and some other places (BM?). The idea is that, instead of conditional compilation using `feature` pragmas, we use generics and monomorphization to compile two versions of every function, and avoid the performance hit of everywhere having to wrap/unwrap options.

I _still_ hate the fact that I'm passing in these `&mut NullTrace` everywhere, when 90% of the callsites don't _care_ about the trace. I still intend to move the trace _onto_ the Eval struct at some point, but this is just a first step to see how I like the API.

bench 6683911