### PR TITLE
Time/score stability

### DIFF
--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -171,7 +171,7 @@ impl Position {
             }
             prev_best_move = Some(pv.pv_move());
 
-            if score >= previous_score - 20 && score <= previous_score + 20 {
+            if score >= previous_score - 10 && score <= previous_score + 10 {
                 score_stability += 1;
             } else {
                 score_stability = 0;

--- a/simbelmyne/src/search.rs
+++ b/simbelmyne/src/search.rs
@@ -117,6 +117,8 @@ impl Position {
         let mut pv = PVTable::new();
         let mut prev_best_move = None;
         let mut best_move_stability = 0;
+        let mut previous_score = 0;
+        let mut score_stability = 0;
         history.clear_nodes();
 
         // If there is only one legal move, notify the the time controller that
@@ -167,15 +169,20 @@ impl Position {
             } else {
                 best_move_stability = 0;
             }
-
-            // Store the new best move for the next iteration
             prev_best_move = Some(pv.pv_move());
+
+            if score >= previous_score - 20 && score <= previous_score + 20 {
+                score_stability += 1;
+            } else {
+                score_stability = 0;
+            }
+            previous_score = score;
 
             // Calculate the fraction of nodes spent on the current best move
             let bm_nodes = search.history.get_nodes(pv.pv_move());
             let node_frac = bm_nodes as f64 / search.nodes as f64;
 
-            search.tc.update(best_move_stability, node_frac);
+            search.tc.update(best_move_stability, node_frac, score_stability);
 
             ////////////////////////////////////////////////////////////////////
             //

--- a/simbelmyne/src/time_control.rs
+++ b/simbelmyne/src/time_control.rs
@@ -219,7 +219,11 @@ impl TimeController {
                 let mut adjusted_soft_time = self.soft_time.as_millis() as f64;
                 adjusted_soft_time *= self.bm_stability_factor;
                 adjusted_soft_time *= self.node_frac_factor;
-                adjusted_soft_time *= self.score_stability_factor;
+
+                if depth >= 7 {
+                    adjusted_soft_time *= self.score_stability_factor;
+                }
+
                 self.elapsed().as_millis() < adjusted_soft_time as u128
             },
 


### PR DESCRIPTION
```
Elo   | 2.56 +- 2.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 43386 W: 11487 L: 11167 D: 20732
Penta | [709, 5165, 9753, 5229, 837]
https://chess.samroelants.com/test/267/
```