### PR TITLE
Try not to underflow when reducing search depth

### DIFF
--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -619,7 +619,7 @@ impl Position {
                 // Search with zero-window at reduced depth
                 score = -next_position.zero_window(
                     ply + 1, 
-                    (depth as i16 - 1 + extension - reduction) as usize, 
+                    (depth as i16 - 1 + extension - reduction).max(0) as usize, 
                     -alpha, 
                     tt, 
                     pawn_cache,
@@ -634,7 +634,7 @@ impl Position {
                 if score > alpha && reduction > 0 {
                     score = -next_position.zero_window(
                         ply + 1, 
-                        (depth as i16 + extension - 1) as usize, 
+                        (depth as i16 + extension - 1).max(0) as usize, 
                         -alpha, 
                         tt, 
                         pawn_cache,
@@ -650,7 +650,7 @@ impl Position {
                 if score > alpha && score < beta {
                     score = -next_position.negamax::<PV>(
                         ply + 1, 
-                        (depth as i16 + extension - 1) as usize, 
+                        (depth as i16 + extension - 1).max(0) as usize, 
                         -beta, 
                         -alpha,
                         tt, 


### PR DESCRIPTION
Not sure if this fixes anything, but I _think_ this is a theoretical possibility? If the reduction takes the search depth to 0 (which it can, and probably shouldn't?), then a negext would be able to underflow the search depth.

```
Elo   | 0.80 +- 3.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.55 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 9526 W: 2605 L: 2583 D: 4338
Penta | [133, 980, 2513, 1006, 131]
https://chess.samroelants.com/test/350/
```
bench 6183120