### PR TITLE
Add `is_legal` check before playing TT move

### DIFF
--- a/chess/src/square.rs
+++ b/chess/src/square.rs
@@ -188,10 +188,11 @@ impl Square {
 
         let can_push = push_mask.overlap(blockers).is_empty();
         let can_dbl_push = on_original_rank 
+            && can_push 
             && dbl_push_mask.overlap(blockers).is_empty();
 
         if can_dbl_push {
-            dbl_push_mask
+            push_mask | dbl_push_mask
         } else if can_push {
             push_mask
         } else {

--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -296,8 +296,8 @@ impl<'a> MovePicker<'a> {
         if self.stage == Stage::TTMove {
             self.stage = Stage::GenerateTacticals;
 
-            if let Some(tt_move) = self.tt_move {
-                return Some(tt_move)
+            if self.tt_move.is_some_and(|mv| self.position.board.is_legal(mv)) {
+                return self.tt_move;
             }
         } 
 


### PR DESCRIPTION
Simplify logic slightly, and start checking TT move for legality.

Mostly necessary for LazySMP, which is causing _way_ more TT collisions, for some reason.
(e.g., https://chess.samroelants.com/test/375/)

With the legality check in place, we have 0 crashes again!
(https://chess.samroelants.com/test/383/)

Technically, the bit of extra work we're doing is gonna cost us 2-3 elo, but that seems to be offset by the fact that the LazySMP refactor might gain us 2-3 elo as well.

Non-regression for `is_legal` + LazySMP: 
```
Elo   | -1.52 +- 2.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -0.12 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 25144 W: 7047 L: 7157 D: 10940
Penta | [376, 2788, 6355, 2676, 377]
https://chess.samroelants.com/test/384/
```

I'll leave the test running, but happy to merge as is.

bench 6393411