### PR TITLE
Add custom Default implementations for PawnStructure and PawnCacheEntry

### DIFF
--- a/simbelmyne/src/evaluate/pawn_cache.rs
+++ b/simbelmyne/src/evaluate/pawn_cache.rs
@@ -6,13 +6,25 @@ use crate::zobrist::ZHash;
 
 use super::{pawn_structure::PawnStructure, S};
 
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug)]
 pub struct PawnCacheEntry {
     pub hash: ZHash,
     pub score: S,
     pub passers: [Bitboard; 2],
     pub semi_opens: [Bitboard; 2],
     pub outposts: [Bitboard; 2]
+}
+
+impl Default for PawnCacheEntry {
+    fn default() -> Self {
+        Self {
+            hash: ZHash::NULL,
+            score: S::default(),
+            passers: [Bitboard::EMPTY, Bitboard::EMPTY],
+            semi_opens: [!Bitboard::EMPTY, !Bitboard::EMPTY],
+            outposts: [Bitboard::EMPTY, Bitboard::EMPTY]
+        }
+    }
 }
 
 impl PawnCacheEntry {
@@ -51,11 +63,11 @@ impl PawnCache {
 
     // Check whether the hash appears in the transposition table, and return it 
     // if so.
-    //
     pub fn probe(&self, hash: ZHash) -> Option<PawnCacheEntry> {
         let key = ZKey::from_hash(hash, self.size);
 
         self.table.get(key.0)
+            // .filter(|_| hash != ZHash::NULL)
             .filter(|entry| entry.hash == hash)
             .copied()
     }

--- a/simbelmyne/src/evaluate/pawn_structure.rs
+++ b/simbelmyne/src/evaluate/pawn_structure.rs
@@ -13,7 +13,7 @@ use super::{Score, S};
 const WHITE: bool = true;
 const BLACK: bool = false;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PawnStructure {
     /// The score associated with the pawn structure
     pub score: S,
@@ -28,6 +28,17 @@ pub struct PawnStructure {
     /// Squares that can't be attacked (easily) by opponent pawns, and are
     /// defended by one of our pawns
     pub outposts: [Bitboard; Color::COUNT],
+}
+
+impl Default for PawnStructure {
+    fn default() -> Self {
+        Self {
+            score: S::default(),
+            passed_pawns: [Bitboard::EMPTY, Bitboard::EMPTY],
+            semi_open_files: [!Bitboard::EMPTY, !Bitboard::EMPTY],
+            outposts: [!Bitboard::EMPTY, !Bitboard::EMPTY]
+        }
+    }
 }
 
 impl PawnStructure {


### PR DESCRIPTION
Make sure the "default" is correct for a pawnless board. Otherwise, probing a ZHash(0) entry from the cache might be a pawnless board, or an empty entry, and they'd have different values.