### PR TITLE
Search/eval nmp

### DIFF
--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -239,7 +239,9 @@ impl<'a> SearchRunner<'a> {
         // shouldn't bother searching it any further
         //
         ////////////////////////////////////////////////////////////////////////
-        let nmp_margin = -120 + 20 * depth as Score + nmp_improving_margin() * improving as Score;
+        let nmp_margin = nmp_base_margin() 
+            + nmp_margin_factor() * depth as Score 
+            + nmp_improving_margin() * improving as Score;
 
         let should_null_prune = try_null
             && !PV

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -239,14 +239,14 @@ impl<'a> SearchRunner<'a> {
         // shouldn't bother searching it any further
         //
         ////////////////////////////////////////////////////////////////////////
-        let lmp_margin = 175 + 25 * depth as Score + nmp_improving_margin() * improving as Score;
+        let nmp_margin = -120 + 20 * depth as Score + nmp_improving_margin() * improving as Score;
 
         let should_null_prune = try_null
             && !PV
             && !in_root
             && !in_check
             && excluded.is_none()
-            && static_eval + lmp_margin >= beta
+            && static_eval + nmp_margin >= beta
             && pos.board.zugzwang_unlikely();
 
         if should_null_prune {

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -239,13 +239,14 @@ impl<'a> SearchRunner<'a> {
         // shouldn't bother searching it any further
         //
         ////////////////////////////////////////////////////////////////////////
+        let lmp_margin = 175 + 25 * depth as Score + nmp_improving_margin() * improving as Score;
 
         let should_null_prune = try_null
             && !PV
             && !in_root
             && !in_check
             && excluded.is_none()
-            && static_eval + nmp_improving_margin() * improving as Score >= beta
+            && static_eval + lmp_margin >= beta
             && pos.board.zugzwang_unlikely();
 
         if should_null_prune {

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -50,6 +50,12 @@ pub mod tunable_params {
     #[uci(min = 0, max = 8, step = 1)]
     const NMP_REDUCTION_FACTOR: usize = 4;
 
+    #[uci(min = 0, max = 100, step = 5)]
+    const NMP_BASE_MARGIN: i32 = -120;
+
+    #[uci(min = -200 , max = 0, step = 10)]
+    const NMP_MARGIN_FACTOR: i32 = 20;
+
     #[uci(min = 0, max = 150, step = 10)]
     const NMP_IMPROVING_MARGIN: i32 = 70;
 


### PR DESCRIPTION
```
Elo   | 5.67 +- 4.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10902 W: 3278 L: 3100 D: 4524
Penta | [191, 1255, 2431, 1333, 241]
https://chess.samroelants.com/test/470/
```