### PR TITLE
Store eval in TT straight away

### DIFF
--- a/simbelmyne/src/evaluate/util.rs
+++ b/simbelmyne/src/evaluate/util.rs
@@ -132,6 +132,7 @@ pub trait ScoreExt {
     const MINUS_INF: Self;
     const PLUS_INF: Self;
     const MATE: Self;
+    const NO_SCORE: Self;
 
     /// Return whether or not a score is a mate score
     fn is_mate(self) -> bool;
@@ -152,6 +153,8 @@ impl ScoreExt for Score {
     const MINUS_INF: Self = Self::MIN + 1;
     const PLUS_INF: Self = Self::MAX;
     const MATE: Self = 20_000;
+    const NO_SCORE: Self = Self::MINUS_INF;
+
 
     fn is_mate(self) -> bool {
         Self::abs(self) >= Self::MATE - MAX_MOVES as i32

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -141,7 +141,20 @@ impl<'a> SearchRunner<'a> {
         } else if let Some(entry) = tt_entry {
             entry.get_eval()
         } else {
-            eval_state.total(&pos.board, &mut NullTrace)
+            let eval = eval_state.total(&pos.board, &mut NullTrace);
+
+            self.tt.insert(TTEntry::new(
+                pos.hash,
+                Move::NULL,
+                Score::NO_SCORE,
+                eval,
+                0,
+                NodeType::Upper,
+                self.tt.get_age(),
+                ply
+            ));
+
+            eval
         };
 
         let static_eval = if excluded.is_some() {

--- a/simbelmyne/src/search/quiescence.rs
+++ b/simbelmyne/src/search/quiescence.rs
@@ -62,10 +62,20 @@ impl<'a> SearchRunner<'a> {
             -Score::MATE + ply as Score } else if let Some(entry) = tt_entry {
             entry.get_eval()
         } else {
-            // let idx = search.history.indices[ply-1];
-            // let new_eval = eval_state.play_move(idx, &self.board);
-            // search.stack[ply].incremental_eval = Some(new_eval);
-            eval_state.total(&pos.board, &mut NullTrace)
+            let eval = eval_state.total(&pos.board, &mut NullTrace);
+
+            self.tt.insert(TTEntry::new(
+                pos.hash,
+                Move::NULL,
+                Score::NO_SCORE,
+                eval,
+                0,
+                NodeType::Upper,
+                self.tt.get_age(),
+                ply
+            ));
+
+            eval
         };
 
         let static_eval = if in_check {

--- a/simbelmyne/src/transpositions.rs
+++ b/simbelmyne/src/transpositions.rs
@@ -313,10 +313,10 @@ impl TTable {
         let key: ZKey = ZKey::from_hash(entry.hash, self.size);
         let existing: TTEntry = self.table[key.0].load();
 
-        if existing.is_empty() {
-            self.table[key.0].store(&entry);
-        } else if existing.get_age() != self.get_age() 
-            || existing.depth < entry.depth 
+        if existing.is_empty()
+            || existing.get_move().is_none()
+            || existing.get_age() != self.get_age() 
+            || existing.depth <= entry.depth 
             || existing.hash != entry.hash
             || entry.get_type() == Exact && existing.get_type() != Exact
         {


### PR DESCRIPTION
Always store the eval, even if we don't make it to the end of negamax (where we normally store the full TT entry).

```
Elo   | 5.63 +- 4.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11226 W: 3329 L: 3147 D: 4750
Penta | [210, 1302, 2434, 1430, 237]
https://chess.samroelants.com/test/484/
```

bench 6498304