### PR TITLE
Fix `MovePicker::current_score` helper

### DIFF
--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -124,7 +124,7 @@ impl<'pos> MovePicker<'pos> {
     }
 
     pub fn current_score(&self) -> i32 {
-        self.scores[self.index]
+        self.scores[self.index - 1]
     }
 
     /// Swap moves at provided indices, and update their associated scores.


### PR DESCRIPTION
```
Elo   | -0.66 +- 1.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 48422 W: 13955 L: 14047 D: 20420
Penta | [1066, 5769, 10587, 5769, 1020]
https://chess.samroelants.com/test/526/
```

Since we increment the index after yielding each move, the "current score" is actually the score corresponding to the previous index.

Feels messy, should probably revisit this at some point...

bench 6393856