### PR TITLE
Add history pruning

### DIFF
--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -61,7 +61,7 @@ pub enum Stage {
 /// moves as lazily as possible.
 pub struct MovePicker<'pos> {
     /// The current stage the move picker is in
-    stage: Stage,
+    pub stage: Stage,
 
     /// The stored moves in the move picker
     moves: MoveList,
@@ -114,7 +114,6 @@ impl<'pos> MovePicker<'pos> {
             index: 0,
             only_good_tacticals: !ALL_MOVES,
             ply
-
         }
     }
 
@@ -125,6 +124,11 @@ impl<'pos> MovePicker<'pos> {
 
     pub fn current_score(&self) -> i32 {
         self.scores[self.index - 1]
+    }
+
+    pub fn skip_quiets(&mut self) {
+        self.index = self.bad_tactical_index;
+        self.stage = Stage::BadTacticals;
     }
 
     /// Swap moves at provided indices, and update their associated scores.
@@ -156,7 +160,7 @@ impl<'pos> MovePicker<'pos> {
     /// Do a pass over all the moves, starting at the `start` up 
     /// till `end` (exclusive). Find the largest scoring move, and swap it 
     /// to `start`, then return it.
-    pub fn partial_sort(&mut self,start: usize, end: usize) -> Option<Move> {
+    pub fn partial_sort(&mut self, start: usize, end: usize) -> Option<Move> {
         if start == end {
             return None;
         }

--- a/simbelmyne/src/search/negamax.rs
+++ b/simbelmyne/src/search/negamax.rs
@@ -440,6 +440,27 @@ impl<'a> SearchRunner<'a> {
 
             ////////////////////////////////////////////////////////////////////
             //
+            // History pruning
+            //
+            // We skip quiet moves with a sufficiently bad history score
+            //
+            ////////////////////////////////////////////////////////////////////
+
+            let hp_margin = hist_pruning_offset() + hist_pruning_margin() * depth as i32;
+
+            if !in_check
+                && !PV
+                && !best_score.is_mate()
+                && mv.is_quiet()
+                && depth <= hist_pruning_threshold()
+                && legal_moves.current_score() <= hp_margin {
+                legal_moves.skip_quiets();
+                continue;
+            }
+
+
+            ////////////////////////////////////////////////////////////////////
+            //
             // Singular extensions (Part 2)
             //
             // If there is a candidate SE move, we do a verification search,

--- a/simbelmyne/src/search/params.rs
+++ b/simbelmyne/src/search/params.rs
@@ -145,12 +145,26 @@ pub mod tunable_params {
     // SEE pruning
     //
     ////////////////////////////////////////////////////////////////////////////
-    
+
     #[uci(min = 0, max = 200, step = 10)]
     const SEE_QUIET_MARGIN: i32 = 40;
 
     #[uci(min = 0, max = 200, step = 10)]
     const SEE_TACTICAL_MARGIN: i32 = 100;
+
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    // History pruning
+    //
+    ////////////////////////////////////////////////////////////////////////////
+    #[uci(min = 0, max = 10, step = 1)]
+    const HIST_PRUNING_THRESHOLD: usize = 5;
+
+    #[uci(min = -4096, max = 0, step = 200)]
+    const HIST_PRUNING_MARGIN: i32 = -1500;
+
+    #[uci(min = -4096, max = 4096, step = 400)]
+    const HIST_PRUNING_OFFSET: i32 = -1000;
 
     ////////////////////////////////////////////////////////////////////////////
     //


### PR DESCRIPTION
```
Elo   | 8.23 +- 5.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6882 W: 2091 L: 1928 D: 2863
Penta | [127, 774, 1515, 859, 166]
https://chess.samroelants.com/test/527/
```

Feels like there's plenty of room for playing around here.

lmr depth? prune in PV? Tweak the values?

bench 6842368