### PR TITLE
Use hist score in SEE threshold for bad captures

### DIFF
--- a/simbelmyne/src/move_picker.rs
+++ b/simbelmyne/src/move_picker.rs
@@ -182,10 +182,11 @@ impl<'pos> MovePicker<'pos> {
         return Some(best_move);
     }
 
-    fn is_good_tactical(&self, mv: Move) -> bool {
+    fn is_good_tactical(&self, mv: Move, history: &History) -> bool {
         use PieceType::*;
         if mv.is_capture() {
-            self.position.board.see(mv, 0)
+            let hist_score = history.get_hist_score(mv, &self.position.board);
+            self.position.board.see(mv, -hist_score / 32)
         } else {
             mv.get_promo_type().is_some_and(|pt| pt == Queen)
         }
@@ -350,7 +351,7 @@ impl<'a> MovePicker<'a> {
             while self.index < self.bad_tactical_index {
                 let tactical = self.partial_sort(self.index, self.bad_tactical_index);
 
-                if self.is_good_tactical(tactical.unwrap()) {
+                if self.is_good_tactical(tactical.unwrap(), history) {
                     self.index += 1;
                     return tactical;
                 } else {


### PR DESCRIPTION
```
Elo   | 13.89 +- 7.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3728 W: 1169 L: 1020 D: 1539
Penta | [69, 388, 834, 471, 102]
https://chess.samroelants.com/test/556/
```

bench 7249920