### PR TITLE
Track cutnodes and reduce more in said cutnodes

### DIFF
--- a/simbelmyne/src/search/aspiration.rs
+++ b/simbelmyne/src/search/aspiration.rs
@@ -45,6 +45,7 @@ impl<'a> SearchRunner<'a> {
                 beta,
                 pv,
                 Eval::new(&pos.board, &mut NullTrace),
+                false,
                 false
             );
 

--- a/simbelmyne/src/search/zero_window.rs
+++ b/simbelmyne/src/search/zero_window.rs
@@ -13,6 +13,7 @@ impl<'a> SearchRunner<'a> {
         pv: &mut PVTable,
         eval_state: Eval,
         try_null: bool,
+        cutnode: bool,
     ) -> Score {
         self.negamax::<false>(
             pos,
@@ -22,7 +23,8 @@ impl<'a> SearchRunner<'a> {
             value, 
             pv, 
             eval_state, 
-            try_null
+            try_null,
+            cutnode,
         )
     }
 }


### PR DESCRIPTION
```
Elo   | 8.67 +- 5.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6136 W: 1824 L: 1671 D: 2641
Penta | [93, 671, 1417, 764, 123]
https://chess.samroelants.com/test/602/
```

bench 6254592