### PR TITLE
Reduce more in nmp when improving

### DIFF
--- a/engine/src/search/negamax.rs
+++ b/engine/src/search/negamax.rs
@@ -266,8 +266,9 @@ impl<'a> SearchRunner<'a> {
             && pos.board.zugzwang_unlikely();
 
         if should_null_prune {
-            let reduction = (nmp_base_reduction() + depth / nmp_reduction_factor())
-                .min(depth);
+            let mut reduction = nmp_base_reduction() + depth / nmp_reduction_factor();
+            reduction += 2 * improving as usize;
+            reduction = reduction.min(depth);
 
             self.history.push_null_mv();
 
@@ -624,8 +625,7 @@ impl<'a> SearchRunner<'a> {
                 let mut reduction: i16 = 0;
 
                 // Calculate LMR reduction
-                if depth >= lmr_min_depth()
-                    && move_count >= lmr_threshold() + PV as usize {
+                if depth >= lmr_min_depth() && move_count >= lmr_threshold() + PV as usize {
                     // Fetch the base LMR reduction value from the LMR table
                     reduction = lmr_reduction(depth, move_count) as i16;
 
@@ -649,7 +649,6 @@ impl<'a> SearchRunner<'a> {
 
                     // Reduce less when the move gives check
                     reduction -= next_position.board.in_check() as i16;
-
 
                     // Reduce moves with good history less, with bad history more
                     if mv.is_quiet() {


### PR DESCRIPTION
```
Elo   | 6.30 +- 4.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9378 W: 2761 L: 2591 D: 4026
Penta | [155, 1075, 2103, 1157, 199]
https://chess.samroelants.com/test/649/
```

bench 3811328