### PR TITLE
Search/contcorrhist

### DIFF
--- a/engine/src/history_tables/corrhist.rs
+++ b/engine/src/history_tables/corrhist.rs
@@ -24,8 +24,12 @@
 //! NOTE: Would it make more sense to give higher weight to shallow searches? 
 //! Those are clearly the ones that need more correction, because the eval got
 //! it _very_ wrong.
-use chess::piece::Color;
+use std::ops::{Index, IndexMut};
+
+use chess::{piece::{Color, Piece}, square::Square};
 use crate::{evaluate::Score, zobrist::ZHash};
+
+use super::history::HistoryIndex;
 
 #[derive(Debug)]
 pub struct CorrHistTable {
@@ -64,7 +68,7 @@ impl CorrHistTable {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct CorrHistEntry(Score);
 
 impl CorrHistEntry {
@@ -115,5 +119,33 @@ impl CorrHistEntry {
             .clamp(self.0 - Self::MAX_UPDATE, self.0 + Self::MAX_UPDATE)
             // Clamp to max allowed value
             .clamp(-Self::MAX_VALUE, Self::MAX_VALUE);
+    }
+}
+#[derive(Debug, Copy, Clone)]
+pub struct ContCorrHistTable {
+    scores: [[CorrHistEntry; Square::COUNT]; Piece::COUNT]
+}
+
+pub const MAX_HIST_SCORE: i16 = i16::MAX/2;
+
+impl ContCorrHistTable {
+    pub fn new() -> Self {
+        Self {
+            scores: [[CorrHistEntry(0); Square::COUNT]; Piece::COUNT]
+        }
+    }
+}
+
+impl Index<&HistoryIndex> for ContCorrHistTable {
+    type Output = CorrHistEntry;
+
+    fn index(&self, index: &HistoryIndex) -> &Self::Output {
+        &self.scores[index.moved][index.tgt()]
+    }
+}
+
+impl IndexMut<&HistoryIndex> for ContCorrHistTable{
+    fn index_mut(&mut self, index: &HistoryIndex) -> &mut Self::Output {
+        &mut self.scores[index.moved][index.tgt()]
     }
 }

--- a/engine/src/history_tables/history.rs
+++ b/engine/src/history_tables/history.rs
@@ -18,6 +18,7 @@ use crate::search::params::hist_bonus_const;
 use crate::search::params::hist_bonus_const_cutoff;
 use crate::search::params::hist_bonus_linear;
 use crate::search::params::hist_bonus_quadratic;
+use crate::zobrist::ZHash;
 use std::ops::{Add, AddAssign, Index, IndexMut, Neg, Sub, SubAssign};
 use chess::board::Board;
 use chess::square::Square;
@@ -111,12 +112,24 @@ impl HistoryIndex {
     }
 }
 
+impl Into<ZHash> for &HistoryIndex {
+    fn into(self) -> ZHash {
+        let mut hash = ZHash::default();
+        hash.toggle_piece(self.moved, self.tgt());
+
+        // Hack to make sure we don't accidentally collide with any other keys
+        hash.toggle_ep(self.src());
+
+        hash
+    }
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 //
 // History score
 //
 ////////////////////////////////////////////////////////////////////////////////
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct HistoryScore(i16);
 

--- a/engine/src/history_tables/mod.rs
+++ b/engine/src/history_tables/mod.rs
@@ -2,7 +2,7 @@ use arrayvec::ArrayVec;
 use capthist::TacticalHistoryTable;
 use chess::{board::Board, movegen::moves::Move, piece::PieceType, square::Square};
 use conthist::ContHist;
-use corrhist::CorrHistTable;
+use corrhist::{ContCorrHistTable, CorrHistTable};
 use countermoves::CountermoveTable;
 use history::{HistoryIndex, HistoryScore};
 use killers::Killers;
@@ -25,6 +25,7 @@ pub struct History {
     pub cont_hist: Box<ContHist>,
     pub tact_hist: Box<TacticalHistoryTable>,
     pub corr_hist: Box<CorrHistTable>,
+    pub contcorr_hist: ContCorrHistTable,
     countermoves: Box<CountermoveTable>,
     pub killers: [Killers; MAX_DEPTH],
     pub indices: ArrayVec<HistoryIndex, MAX_DEPTH>,
@@ -40,6 +41,7 @@ impl History {
             tact_hist: TacticalHistoryTable::boxed(),
             countermoves: CountermoveTable::boxed(),
             corr_hist: CorrHistTable::boxed(),
+            contcorr_hist: ContCorrHistTable::new(),
             killers: [Killers::new(); MAX_DEPTH],
             indices: ArrayVec::new(),
             rep_hist: ArrayVec::new(),

--- a/engine/src/search/negamax.rs
+++ b/engine/src/search/negamax.rs
@@ -181,11 +181,19 @@ impl<'a> SearchRunner<'a> {
                 .get(us, pos.minor_hash)
                 .corr();
 
+            let cont_correction = self.history.indices.get(ply - 2)
+                .map(|idx| {
+                    self.history.corr_hist
+                    .get(us, idx.into())
+                    .corr()
+                }).unwrap_or_default();
+
             raw_eval 
                 + pawn_correction 
                 + (w_nonpawn_correction + b_nonpawn_correction) / 2
                 + 4 * material_correction
                 + minor_correction
+                + cont_correction
         };
 
         // Store the eval in the search stack
@@ -857,6 +865,13 @@ impl<'a> SearchRunner<'a> {
                 self.history.corr_hist
                     .get_mut(us, pos.minor_hash)
                     .update(best_score, static_eval, depth);
+
+                // Update the cont corrhist
+                if let Some(idx) = self.history.indices.get(ply - 2) {
+                    self.history.corr_hist
+                        .get_mut(us, idx.into())
+                        .update(best_score, static_eval, depth);
+                }
             }
 
             ///////////////////////////////////////////////////////////////////

--- a/engine/src/search/negamax.rs
+++ b/engine/src/search/negamax.rs
@@ -183,8 +183,7 @@ impl<'a> SearchRunner<'a> {
 
             let cont_correction = self.history.indices.get(ply - 2)
                 .map(|idx| {
-                    self.history.corr_hist
-                    .get(us, idx.into())
+                    self.history.contcorr_hist[idx]
                     .corr()
                 }).unwrap_or_default();
 
@@ -193,7 +192,7 @@ impl<'a> SearchRunner<'a> {
                 + (w_nonpawn_correction + b_nonpawn_correction) / 2
                 + 4 * material_correction
                 + minor_correction
-                + cont_correction
+                + cont_correction / 2
         };
 
         // Store the eval in the search stack
@@ -868,8 +867,8 @@ impl<'a> SearchRunner<'a> {
 
                 // Update the cont corrhist
                 if let Some(idx) = self.history.indices.get(ply - 2) {
-                    self.history.corr_hist
-                        .get_mut(us, idx.into())
+                    self.history
+                        .contcorr_hist[idx]
                         .update(best_score, static_eval, depth);
                 }
             }

--- a/engine/src/search/quiescence.rs
+++ b/engine/src/search/quiescence.rs
@@ -101,11 +101,18 @@ impl<'a> SearchRunner<'a> {
                 .get(us, pos.minor_hash)
                 .corr();
 
+            let cont_correction = self.history.indices.get(ply - 2)
+                .map(|idx| {
+                    self.history.contcorr_hist[idx]
+                    .corr()
+                }).unwrap_or_default();
+
             raw_eval 
                 + pawn_correction 
                 + (w_nonpawn_correction + b_nonpawn_correction) / 2
                 + 4 * material_correction
                 + minor_correction
+                + cont_correction / 2
         };
 
         if ply >= MAX_DEPTH {


### PR DESCRIPTION
```
Elo   | 4.38 +- 3.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15932 W: 4611 L: 4410 D: 6911
Penta | [276, 1825, 3568, 2016, 281]
https://chess.samroelants.com/test/667/
```