### PR TITLE
Search/ttpv

### DIFF
--- a/engine/src/search/negamax.rs
+++ b/engine/src/search/negamax.rs
@@ -614,9 +614,6 @@ impl<'a> SearchRunner<'a> {
           // Reduce less when the move gives check
           reduction -= next_position.board.in_check() as i16;
 
-          // Reduce less when the node was a PV node elsewhere in the tree
-          reduction -= ttpv as i16;
-
           // Reduce moves with good history less, with bad history
           // more
           if mv.is_quiet() {

--- a/engine/src/search/negamax.rs
+++ b/engine/src/search/negamax.rs
@@ -615,7 +615,7 @@ impl<'a> SearchRunner<'a> {
           reduction -= next_position.board.in_check() as i16;
 
           // Reduce less when the node was a PV node elsewhere in the tree
-          // reduction -= ttpv as i16;
+          reduction -= ttpv as i16;
 
           // Reduce moves with good history less, with bad history
           // more

--- a/engine/src/search/negamax.rs
+++ b/engine/src/search/negamax.rs
@@ -69,7 +69,7 @@ impl<'a> SearchRunner<'a> {
     ////////////////////////////////////////////////////////////////////////
 
     if depth == 0 || ply >= MAX_DEPTH {
-      return self.quiescence_search(&pos, ply, alpha, beta, eval_state);
+      return self.quiescence_search::<PV>(&pos, ply, alpha, beta, eval_state);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -119,6 +119,8 @@ impl<'a> SearchRunner<'a> {
       }
     }
 
+    let ttpv = PV || tt_entry.is_some_and(|entry| entry.get_ttpv());
+
     ////////////////////////////////////////////////////////////////////////
     //
     // Compute the static evaluation
@@ -144,6 +146,7 @@ impl<'a> SearchRunner<'a> {
         0,
         NodeType::Upper,
         self.tt.get_age(),
+        ttpv,
         ply,
       ));
 
@@ -815,6 +818,7 @@ impl<'a> SearchRunner<'a> {
         depth,
         node_type,
         self.tt.get_age(),
+        ttpv,
         ply,
       ));
     }

--- a/engine/src/search/negamax.rs
+++ b/engine/src/search/negamax.rs
@@ -605,8 +605,8 @@ impl<'a> SearchRunner<'a> {
           // Reduce more in expected cutnodes
           reduction += cutnode as i16;
 
-          // Reduce non-pv nodes more
-          reduction -= PV as i16;
+          // Reduce less in (current or historically) pv nodes
+          reduction -= ttpv as i16;
 
           // Reduce less when the current position is in check
           reduction -= in_check as i16;

--- a/engine/src/search/negamax.rs
+++ b/engine/src/search/negamax.rs
@@ -614,6 +614,9 @@ impl<'a> SearchRunner<'a> {
           // Reduce less when the move gives check
           reduction -= next_position.board.in_check() as i16;
 
+          // Reduce less when the node was a PV node elsewhere in the tree
+          reduction -= ttpv as i16;
+
           // Reduce moves with good history less, with bad history
           // more
           if mv.is_quiet() {

--- a/engine/src/search/negamax.rs
+++ b/engine/src/search/negamax.rs
@@ -605,8 +605,8 @@ impl<'a> SearchRunner<'a> {
           // Reduce more in expected cutnodes
           reduction += cutnode as i16;
 
-          // Reduce less in (current or historically) pv nodes
-          reduction -= ttpv as i16;
+          // Reduce less in PV nodes
+          reduction -= PV as i16;
 
           // Reduce less when the current position is in check
           reduction -= in_check as i16;

--- a/engine/src/search/negamax.rs
+++ b/engine/src/search/negamax.rs
@@ -615,7 +615,7 @@ impl<'a> SearchRunner<'a> {
           reduction -= next_position.board.in_check() as i16;
 
           // Reduce less when the node was a PV node elsewhere in the tree
-          reduction -= ttpv as i16;
+          // reduction -= ttpv as i16;
 
           // Reduce moves with good history less, with bad history
           // more

--- a/engine/src/search/quiescence.rs
+++ b/engine/src/search/quiescence.rs
@@ -141,23 +141,13 @@ impl<'a> SearchRunner<'a> {
         &mut self.kp_cache,
       );
 
-      let score = if move_count == 0 {
-        -self.quiescence_search::<PV>(
-          &next_position,
-          ply + 1,
-          -beta,
-          -alpha,
-          next_eval,
-        )
-      } else {
-        -self.quiescence_search::<false>(
-          &next_position,
-          ply + 1,
-          -beta,
-          -alpha,
-          next_eval,
-        )
-      };
+      let score = -self.quiescence_search::<PV>(
+        &next_position,
+        ply + 1,
+        -beta,
+        -alpha,
+        next_eval,
+      );
 
       self.history.pop_mv();
       move_count += 1;

--- a/engine/src/search/quiescence.rs
+++ b/engine/src/search/quiescence.rs
@@ -141,13 +141,23 @@ impl<'a> SearchRunner<'a> {
         &mut self.kp_cache,
       );
 
-      let score = -self.quiescence_search::<PV>(
-        &next_position,
-        ply + 1,
-        -beta,
-        -alpha,
-        next_eval,
-      );
+      let score = if move_count == 0 {
+        -self.quiescence_search::<PV>(
+          &next_position,
+          ply + 1,
+          -beta,
+          -alpha,
+          next_eval,
+        )
+      } else {
+        -self.quiescence_search::<false>(
+          &next_position,
+          ply + 1,
+          -beta,
+          -alpha,
+          next_eval,
+        )
+      };
 
       self.history.pop_mv();
       move_count += 1;

--- a/engine/src/search/quiescence.rs
+++ b/engine/src/search/quiescence.rs
@@ -129,13 +129,6 @@ impl<'a> SearchRunner<'a> {
     let mut move_count = 0;
 
     while let Some(mv) = tacticals.next(&self.history) {
-      ////////////////////////////////////////////////////////////////////
-      //
-      // Play the move
-      //
-      // Play the move and recurse down the tree
-      //
-      ////////////////////////////////////////////////////////////////////
       self.history.push_mv(mv, &pos.board);
       self.tt.prefetch(pos.approx_hash_after(mv));
 
@@ -148,23 +141,13 @@ impl<'a> SearchRunner<'a> {
         &mut self.kp_cache,
       );
 
-      let score = if move_count == 0 {
-        -self.quiescence_search::<PV>(
-          &next_position,
-          ply + 1,
-          -beta,
-          -alpha,
-          next_eval,
-        )
-      } else {
-        -self.quiescence_search::<false>(
-          &next_position,
-          ply + 1,
-          -beta,
-          -alpha,
-          next_eval,
-        )
-      };
+      let score = -self.quiescence_search::<PV>(
+        &next_position,
+        ply + 1,
+        -beta,
+        -alpha,
+        next_eval,
+      );
 
       self.history.pop_mv();
       move_count += 1;

--- a/engine/src/transpositions.rs
+++ b/engine/src/transpositions.rs
@@ -55,11 +55,10 @@ pub struct TTInfo(u8);
 
 impl TTInfo {
   const TYPE_MASK: u8 = 0b00000011;
-  const TTPV_MASK: u8 = 0b00000100;
   const MAX_AGE: u8 = 1 << 5;
 
   pub fn new(age: u8, node_type: NodeType, ttpv: bool) -> Self {
-    TTInfo(age << 3 + (ttpv as u8) << 2 + node_type as u8)
+    TTInfo(age << 3 | (ttpv as u8) << 2 | node_type as u8)
   }
 
   pub fn age(self) -> u8 {
@@ -67,7 +66,7 @@ impl TTInfo {
   }
 
   pub fn ttpv(self) -> bool {
-    (self.0 & Self::TTPV_MASK) >> 2 != 0
+    self.0 & 0b100 != 0
   }
 
   pub fn node_type(self) -> NodeType {

--- a/engine/src/transpositions.rs
+++ b/engine/src/transpositions.rs
@@ -56,14 +56,11 @@ pub struct TTInfo(u8);
 impl TTInfo {
   const TYPE_MASK: u8 = 0b00000011;
   const TTPV_MASK: u8 = 0b00000100;
-  const MAX_AGE: u8 = 1 << 5;
 
   pub fn new(age: u8, node_type: NodeType, ttpv: bool) -> Self {
-    let age = age & (Self::MAX_AGE - 1); // Clamp age to allowed range
-
     TTInfo(age << 3 + (ttpv as u8) << 2 + node_type as u8)
-
   }
+
   pub fn age(self) -> u8 {
     self.0 >> 3
   }


### PR DESCRIPTION
This just adds the ttpv tracking.

Couldn't get ttpv lmr working just yet, but there's a bunch of other things I want to try with ttpv, so might as well keep the tracking in place for now.

```
Elo   | -0.12 +- 2.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.39 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 25284 W: 7154 L: 7163 D: 10967
Penta | [327, 2650, 6678, 2679, 308]
https://chess.samroelants.com/test/685/
```