### PR TITLE
Use ttpv in tt replacement depth

### DIFF
--- a/engine/src/transpositions.rs
+++ b/engine/src/transpositions.rs
@@ -342,7 +342,7 @@ impl TTable {
     if existing.is_empty()
       || existing.get_move().is_none()
       || existing.get_age() != self.get_age()
-      || existing.depth <= entry.depth
+      || existing.depth <= entry.depth + 2 * entry.get_ttpv() as u8
       || existing.hash != entry.hash
       || entry.get_type() == Exact && existing.get_type() != Exact
     {


### PR DESCRIPTION
```
Elo   | 3.25 +- 2.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 25876 W: 7469 L: 7227 D: 11180
Penta | [447, 2997, 5850, 3155, 489]
https://chess.samroelants.com/test/688/
```

bench 4286464