### PR TITLE
1 ply contcorrhist

### DIFF
--- a/engine/src/history_tables/corrhist.rs
+++ b/engine/src/history_tables/corrhist.rs
@@ -53,6 +53,10 @@ impl History {
     let material = self.mat_corr[us][pos.material_hash].value();
     let minor = self.minor_corr[us][pos.minor_hash].value();
 
+    let cont1 = self.indices.get(ply - 1)
+      .map(|idx| self.contcorr_hist[*idx].value())
+      .unwrap_or_default();
+
     let cont2 = self.indices.get(ply - 2)
       .map(|idx| self.contcorr_hist[*idx].value())
       .unwrap_or_default();
@@ -62,6 +66,7 @@ impl History {
       + nonpawn_corr_weight() * b_nonpawn
       + material_corr_weight() * material
       + minor_corr_weight() * minor
+      + 256 * cont1
       + cont_corr_weight() * cont2;
 
     correction / (256 * CorrHistEntry::SCALE)
@@ -83,6 +88,10 @@ impl History {
     self.b_nonpawn_corr[us][pos.nonpawn_hashes[Black]].update(corr, depth);
     self.mat_corr[us][pos.material_hash].update(corr, depth);
     self.minor_corr[us][pos.minor_hash].update(corr, depth);
+
+    if let Some(idx) = self.indices.get(ply - 1) {
+      self.contcorr_hist[*idx].update(corr, depth);
+    }
 
     if let Some(idx) = self.indices.get(ply - 2) {
       self.contcorr_hist[*idx].update(corr, depth);

--- a/engine/src/history_tables/corrhist.rs
+++ b/engine/src/history_tables/corrhist.rs
@@ -54,11 +54,11 @@ impl History {
     let minor = self.minor_corr[us][pos.minor_hash].value();
 
     let cont1 = self.indices.get(ply - 1)
-      .map(|idx| self.contcorr_hist[*idx].value())
+      .map(|idx| self.contcorr_hist[us][*idx].value())
       .unwrap_or_default();
 
     let cont2 = self.indices.get(ply - 2)
-      .map(|idx| self.contcorr_hist[*idx].value())
+      .map(|idx| self.contcorr_hist[us][*idx].value())
       .unwrap_or_default();
 
     let correction = pawn_corr_weight() * pawn
@@ -90,11 +90,11 @@ impl History {
     self.minor_corr[us][pos.minor_hash].update(corr, depth);
 
     if let Some(idx) = self.indices.get(ply - 1) {
-      self.contcorr_hist[*idx].update(corr, depth);
+      self.contcorr_hist[us][*idx].update(corr, depth);
     }
 
     if let Some(idx) = self.indices.get(ply - 2) {
-      self.contcorr_hist[*idx].update(corr, depth);
+      self.contcorr_hist[us][*idx].update(corr, depth);
     }
   }
 }

--- a/engine/src/history_tables/mod.rs
+++ b/engine/src/history_tables/mod.rs
@@ -33,7 +33,7 @@ pub struct History {
   pub b_nonpawn_corr: [Hash<CorrHistEntry, CORRHIST_SIZE>; Color::COUNT],
   pub minor_corr: [Hash<CorrHistEntry, CORRHIST_SIZE>; Color::COUNT],
   pub mat_corr: [Hash<CorrHistEntry, CORRHIST_SIZE>; Color::COUNT],
-  pub contcorr_hist: Butterfly<CorrHistEntry>,
+  pub contcorr_hist: [Butterfly<CorrHistEntry>; Color::COUNT],
   pub countermoves: Butterfly<Option<Move>>,
   pub killers: [Killers; MAX_DEPTH],
   pub indices: ArrayVec<HistoryIndex, MAX_DEPTH>,


### PR DESCRIPTION
```
Elo   | 4.19 +- 3.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16336 W: 4783 L: 4586 D: 6967
Penta | [264, 1848, 3768, 2003, 285]
https://chess.samroelants.com/test/935/
```

Rebased this test on top of something else (nonfunctional), but the implementation is identical